### PR TITLE
Update embulk-api:0.10.31 to embulk-spi:0.10.44

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "java"
-    id "java-library"
     id "maven-publish"
     id "signing"
     id "checkstyle"
@@ -34,14 +33,14 @@ java {
 }
 
 dependencies {
-    compileOnly "org.embulk:embulk-api:0.10.31"
-    compileOnly "org.msgpack:msgpack-core:0.8.11"
+    compileOnly "org.embulk:embulk-spi:0.10.44"
+    compileOnly "org.msgpack:msgpack-core:0.8.24"
 
-    api "com.fasterxml.jackson.core:jackson-core:2.6.7"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.6.7"
 
-    testImplementation "org.embulk:embulk-api:0.10.31"
-    testImplementation "org.msgpack:msgpack-core:0.8.11"
-    testImplementation "junit:junit:4.13"
+    testImplementation "org.embulk:embulk-spi:0.10.44"
+    testImplementation "org.msgpack:msgpack-core:0.8.24"
+    testImplementation "junit:junit:4.13.2"
 }
 
 javadoc {
@@ -52,7 +51,7 @@ javadoc {
         encoding = "UTF-8"
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
-        links "https://javadoc.io/doc/org.msgpack/msgpack-core/0.8.11/"
+        links "https://javadoc.io/doc/org.msgpack/msgpack-core/0.8.24/"
     }
 }
 
@@ -131,6 +130,17 @@ publishing {
                     connection = "scm:git:git://github.com/embulk/embulk-util-json.git"
                     developerConnection = "scm:git:git@github.com:embulk/embulk-util-json.git"
                     url = "https://github.com/embulk/embulk-util-json"
+                }
+
+                withXml {
+                    project.configurations.compileOnly.allDependencies.each { dependency ->
+                        asNode().dependencies[0].appendNode("dependency").with {
+                            it.appendNode("groupId", dependency.group)
+                            it.appendNode("artifactId", dependency.name)
+                            it.appendNode("version", dependency.version)
+                            it.appendNode("scope", "provided")
+                        }
+                    }
                 }
             }
         }

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-org.embulk:embulk-api:0.10.31=compileClasspath
-org.msgpack:msgpack-core:0.8.11=compileClasspath
-org.slf4j:slf4j-api:1.7.30=compileClasspath
+org.embulk:embulk-spi:0.10.44=compileClasspath
+org.msgpack:msgpack-core:0.8.24=compileClasspath
+org.slf4j:slf4j-api:2.0.6=compileClasspath
 empty=


### PR DESCRIPTION
As embulk-api has been merged into embulk-spi since v0.10.44, this embulk-util-json depends on embulk-spi:0.10.44.

At the same time,
* Update msgpack-core to 0.8.24
* Add compileOnly dependencies (embulk-spi and msgpack-core) as provided
* Change jackson-core to "implementation" from "api"