### PR TITLE
Sync the "main" branch to "master"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,39 @@
+name: Sync main to master
+on:
+  push:
+    branches:
+      - "main"
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    outputs:
+      hash-master: ${{ steps.hash-master.outputs.hash-master }}
+      hash-main: ${{ steps.hash-main.outputs.hash-main }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - id: hash-master
+      name: Hash the master branch
+      run: |
+        hash_master=$( git rev-parse origin/master )
+        echo "$hash_master"
+        echo "hash-master=$hash_master" >> $GITHUB_OUTPUT
+    - id: hash-main
+      name: Hash the main branch
+      run: |
+        hash_main=$( git rev-parse origin/main )
+        echo "$hash_main"
+        echo "hash-main=$hash_main" >> $GITHUB_OUTPUT
+  sync:
+    needs: diff
+    if: needs.diff.outputs.hash-master != needs.diff.outputs.hash-main
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Checkout main
+      run: git checkout main
+    - name: Sync main to master
+      run: git push origin main:master


### PR DESCRIPTION
This pull request does the opposite way of #8: `main` to `master`. It's the preparation to switch the default branch actually.

The two ways `master` to `main` and `main` to `master` can co-exist unless `master` and `main` receive different commits almost at the same time.