### PR TITLE
Allow multiple matches with JsonPointerBasedFilter

### DIFF
--- a/src/main/java/org/embulk/util/json/JsonParser.java
+++ b/src/main/java/org/embulk/util/json/JsonParser.java
@@ -113,7 +113,12 @@ public class JsonParser {
 
     private static com.fasterxml.jackson.core.JsonParser wrapWithPointerFilter(
             final com.fasterxml.jackson.core.JsonParser baseParser, final String offsetInJsonPointer) {
-        return new FilteringParserDelegate(baseParser, new JsonPointerBasedFilter(offsetInJsonPointer), false, false);
+        return new FilteringParserDelegate(
+                baseParser,
+                new JsonPointerBasedFilter(offsetInJsonPointer),
+                false,
+                true  // Allow multiple matches
+                );
     }
 
     private static class StreamParseContext extends AbstractParseContext implements Stream {


### PR DESCRIPTION
JsonParser has not been working well with JSON Pointer for consequent multiple JSONs when used with Jackson 2.7.4+.

For example of multiple JSONs in one stream: {"a": {"b": 1}} {"a": {"b": 2}}

It happened because Jackson 2.7.3 or earlier ignored the `allowMultipleMatches` option. https://github.com/FasterXML/jackson-core/issues/209

This commit fixes this problem by setting the option when used with Jackson 2.7.4+.