### PR TITLE
Implement JsonValuesReader to read JsonValues captured by a set of JsonPointers

### DIFF
--- a/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
@@ -431,10 +431,11 @@ class InternalJsonValuesReader {
     private final JsonPointerTree tree;
     private final int size;
 
-    private ArrayDeque<JsonPointerTree> pointerStack;
-    private ArrayDeque<ParsingContext> parsingStack;
-    private ArrayDeque<StructureBuilder> builderStack;
+    private final ArrayDeque<JsonPointerTree> pointerStack;
+    private final ArrayDeque<ParsingContext> parsingStack;
+    private final ArrayDeque<StructureBuilder> builderStack;
+
+    private final JsonValue[] values;
 
     private boolean hasFinished;
-    private JsonValue[] values;
 }

--- a/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonNull;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
+
+class InternalJsonValuesReader {
+    InternalJsonValuesReader(
+            final JsonParser parser,
+            final JsonPointerTree tree,
+            final int size,
+            final boolean withNumbersFallbackWithLiterals,
+            final double defaultDouble,
+            final long defaultLong) {
+        this.parser = parser;
+        this.tree = tree;
+
+        this.withNumbersFallbackWithLiterals = withNumbersFallbackWithLiterals;
+        this.defaultDouble = defaultDouble;
+        this.defaultLong = defaultLong;
+        this.size = size;
+
+        this.pointerStack = new ArrayDeque<>();
+        this.pointerStack.push(this.tree);
+        this.parsingStack = new ArrayDeque<>();
+        this.builderStack = new ArrayDeque<>();
+
+        this.hasFinished = false;
+
+        this.values = new JsonValue[size];
+        for (int i = 0; i < this.values.length; i++) {
+            this.values[i] = null;
+        }
+    }
+
+    @SuppressWarnings("checkstyle:FallThrough")
+    boolean next() throws IOException {
+        if (this.hasFinished) {
+            return false;
+        }
+
+        final JsonToken token;
+        try {
+            token = this.parser.nextToken();
+        } catch (final com.fasterxml.jackson.core.JsonParseException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        } catch (final IOException ex) {
+            throw ex;
+        } catch (final JsonParseException ex) {
+            throw ex;
+        } catch (final RuntimeException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        }
+
+        if (token == null) {
+            return false;
+        }
+
+        final JsonPointerTree parentPointer = this.pointerStack.peekFirst();
+
+        if (this.parsingStack.isEmpty() && token.isStructStart()) {
+            if (token == JsonToken.START_ARRAY) {
+                this.builderStack.push(new ArrayBuilder());
+            } else if (token == JsonToken.START_OBJECT) {
+                this.builderStack.push(new ObjectBuilder());
+            }
+        }
+
+        // Deepen the pointer stack when the token is a scalar value, START_ARRAY, or START_OBJECT.
+        if (token.isScalarValue() || token.isStructStart()) {
+            if (!this.parsingStack.isEmpty()) {
+                final ParsingContext context = this.parsingStack.getFirst();
+                if (context.isObject()) {
+                    final String propertyName = context.getPropertyName();
+                    if (propertyName == null) {
+                        throw new JsonParseException("Value in JSON Object before any field comes.");
+                    }
+
+                    final JsonPointerTree toBePointer = parentPointer.get(propertyName);
+                    if (toBePointer != null) {
+                        this.pointerStack.push(parentPointer.get(propertyName));
+                    } else {  // This else case includes when parentPointer is INVALID.
+                        this.pointerStack.push(JsonPointerTree.INVALID);
+                    }
+                } else {  // Array
+                    context.incrementIndex();
+                    final String indexInString = context.getIndexInString();
+
+                    // An array index in JSON Pointer does not have ambiguity. An integer index can be
+                    // reverse-resolved uniquely into a string representation.
+                    //
+                    // The ABNF syntax for array indices is:
+                    //
+                    // array-index = %x30 / ( %x31-39 *(%x30-39) )
+                    //               ; "0", or digits without a leading "0"
+                    //
+                    // Implementations will evaluate each reference token against the
+                    // document's contents and will raise an error condition if it fails to
+                    // resolve a concrete value for any of the JSON pointer's reference
+                    // tokens.  For example, if an array is referenced with a non-numeric
+                    // token, an error condition will be raised.  See Section 7 for details.
+                    //
+                    // https://datatracker.ietf.org/doc/html/rfc6901
+
+                    final JsonPointerTree toBePointer = parentPointer.get(indexInString);
+                    if (toBePointer != null) {
+                        this.pointerStack.push(parentPointer.get(indexInString));
+                    } else {  // This else case includes when parentPointer is INVALID.
+                        this.pointerStack.push(JsonPointerTree.INVALID);
+                    }
+                }
+            }
+        }
+
+        if (token == JsonToken.START_ARRAY) {
+            this.parsingStack.push(new ParsingContext(false));
+
+            final List<Integer> captures = this.pointerStack.getFirst().captures();
+            if (!captures.isEmpty()) {
+                this.builderStack.push(new ArrayBuilder());
+            }
+        } else if (token == JsonToken.END_ARRAY) {
+            if (this.parsingStack.isEmpty() || this.parsingStack.pop().isObject()) {
+                throw new JsonParseException("END_ARRAY does not match.");
+            }
+        } else if (token == JsonToken.START_OBJECT) {
+            this.parsingStack.push(new ParsingContext(true));
+
+            final List<Integer> captures = this.pointerStack.getFirst().captures();
+            if (!captures.isEmpty()) {
+                this.builderStack.push(new ObjectBuilder());
+            }
+        } else if (token == JsonToken.END_OBJECT) {
+            if (this.parsingStack.isEmpty() || !this.parsingStack.pop().isObject()) {
+                throw new JsonParseException("END_OBJECT does not match.");
+            }
+        } else if (token == JsonToken.FIELD_NAME) {
+            if (this.parsingStack.isEmpty()) {
+                throw new JsonParseException("FIELD_NAME out of JSON Object.");
+            } else {
+                final ParsingContext context = this.parsingStack.getFirst();
+                if (!context.isObject()) {
+                    throw new JsonParseException("FIELD_NAME in JSON Array.");
+                }
+                context.setPropertyName(this.parser.getCurrentName());
+            }
+        } else if (!token.isScalarValue()) {
+            throw new JsonParseException("Unexpected token in JSON: " + token.toString());
+        }
+
+        if (token.isScalarValue() || token.isStructEnd()) {
+            final JsonValue value;
+            if (token.isScalarValue()) {
+                value = this.getScalarValue(token);
+            } else {  // Structure end
+                if (this.builderStack.isEmpty()) {
+                    value = null;
+                } else {
+                    final StructureBuilder thisBuilder = this.builderStack.pop();
+                    if (token == JsonToken.END_ARRAY && thisBuilder.isObject()) {
+                        throw new JsonParseException("END_ARRAY does not match.");
+                    }
+                    if (token == JsonToken.END_OBJECT && thisBuilder.isArray()) {
+                        throw new JsonParseException("END_OBJECT does not match.");
+                    }
+                    value = thisBuilder.build();
+                }
+            }
+
+            if (value != null) {
+                final JsonPointerTree thisPointer = this.pointerStack.peekFirst();
+                for (final int capture : thisPointer.captures()) {
+                    this.values[capture] = value;
+                }
+
+                if (!this.builderStack.isEmpty()) {
+                    final StructureBuilder parentBuilder = this.builderStack.getFirst();
+                    if (parentBuilder.isArray()) {
+                        parentBuilder.add(value);
+                    } else {  // Object
+                        final ParsingContext context = this.parsingStack.peekFirst();
+                        // If context == null, it's the end of JSON to be parsed while a JSON Pointer "/" is specified.
+                        if (context != null) {
+                            if (!context.isObject()) {
+                                throw new JsonParseException("END_OBJECT does not match.");
+                            } else {
+                                parentBuilder.put(context.getPropertyName(), value);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (token.isScalarValue() || token.isStructEnd()) {  // A scalar value, END_ARRAY, or END_OBJECT
+            if (this.pointerStack.isEmpty()) {
+                throw new JsonParseException("Too many structure ends.");
+            }
+
+            if (this.parsingStack.isEmpty()) {  // When the parsing stack is empty, it should be on the top-level.
+                assert this.pointerStack.size() == 1;
+            } else {
+                this.pointerStack.pop();
+            }
+        }
+
+        if (this.parsingStack.isEmpty()) {
+            this.hasFinished = true;
+        }
+
+        return true;
+    }
+
+    JsonValue[] peekValues() {
+        return this.values;
+    }
+
+    private double getDoubleValue() {
+        try {
+            return this.parser.getDoubleValue();
+        } catch (final IOException ex) {
+            return this.defaultDouble;
+        }
+    }
+
+    private long getLongValue() {
+        try {
+            return this.parser.getLongValue();
+        } catch (final IOException ex) {
+            return this.defaultLong;
+        }
+    }
+
+    private JsonValue getScalarValue(final JsonToken token) throws IOException {
+        switch (token) {
+            case VALUE_NULL:
+                return JsonNull.NULL;
+            case VALUE_TRUE:
+                return JsonBoolean.TRUE;
+            case VALUE_FALSE:
+                return JsonBoolean.FALSE;
+            case VALUE_NUMBER_FLOAT:
+                if (this.withNumbersFallbackWithLiterals) {
+                    return JsonDouble.withLiteral(this.getDoubleValue(), this.parser.getValueAsString());
+                }
+                return JsonDouble.of(this.parser.getDoubleValue());  // throws JsonParseException
+            case VALUE_NUMBER_INT:
+                if (this.withNumbersFallbackWithLiterals) {
+                    return JsonLong.withLiteral(this.getLongValue(), this.parser.getValueAsString());
+                }
+                return JsonLong.of(this.parser.getLongValue());  // throws JsonParseException
+            case VALUE_STRING:
+                return JsonString.of(this.parser.getText());
+            default:
+                throw new JsonParseException("Unexpected token in JSON: " + token.toString());
+        }
+    }
+
+    private static class ParsingContext {
+        ParsingContext(final boolean isObject) {
+            this.isObject = isObject;
+            this.propertyName = null;
+            this.index = -1;
+        }
+
+        boolean isArray() {
+            return !this.isObject;
+        }
+
+        boolean isObject() {
+            return this.isObject;
+        }
+
+        void incrementIndex() {
+            this.index++;
+        }
+
+        String getIndexInString() {
+            return Integer.toString(this.index);
+        }
+
+        void setPropertyName(final String propertyName) {
+            this.propertyName = propertyName;
+        }
+
+        String getPropertyName() {
+            return this.propertyName;
+        }
+
+        @Override
+        public String toString() {
+            if (this.isObject) {
+                if (this.propertyName == null) {
+                    return "null";
+                } else {
+                    return "\"" + this.propertyName + "\"";
+                }
+            } else {
+                return Integer.toString(this.index);
+            }
+        }
+
+        private final boolean isObject;
+        private String propertyName;
+        private int index;
+    }
+
+    private abstract static class StructureBuilder {
+        boolean isArray() {
+            return false;
+        }
+
+        boolean isObject() {
+            return false;
+        }
+
+        abstract StructureBuilder add(JsonValue value);
+
+        abstract StructureBuilder put(String key, JsonValue value);
+
+        abstract JsonValue build();
+    }
+
+    private static class ArrayBuilder extends StructureBuilder {
+        ArrayBuilder() {
+            this.array = new ArrayList<>();
+        }
+
+        @Override
+        boolean isArray() {
+            return true;
+        }
+
+        @Override
+        ArrayBuilder add(final JsonValue value) {
+            this.array.add(value);
+            return this;
+        }
+
+        @Override
+        ArrayBuilder put(final String key, final JsonValue value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        JsonArray build() {
+            return JsonArray.ofList(this.array);
+        }
+
+        @Override
+        public String toString() {
+            return this.array.toString();
+        }
+
+        private final ArrayList<JsonValue> array;
+    }
+
+    private static class ObjectBuilder extends StructureBuilder {
+        ObjectBuilder() {
+            this.entries = new ArrayList<>();
+        }
+
+        @Override
+        boolean isObject() {
+            return true;
+        }
+
+        @Override
+        ArrayBuilder add(final JsonValue value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        ObjectBuilder put(final String key, final JsonValue value) {
+            this.entries.add(new AbstractMap.SimpleEntry<>(key, value));
+            return this;
+        }
+
+        @Override
+        JsonObject build() {
+            return JsonObject.ofEntries(toArray(this.entries));
+        }
+
+        @Override
+        public String toString() {
+            return this.entries.toString();
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Map.Entry<String, JsonValue>[] toArray(final ArrayList<Map.Entry<String, JsonValue>> entries) {
+            return entries.toArray(new Map.Entry[entries.size()]);
+        }
+
+        private final ArrayList<Map.Entry<String, JsonValue>> entries;
+    }
+
+    private final boolean withNumbersFallbackWithLiterals;
+    private final double defaultDouble;
+    private final long defaultLong;
+
+    private final JsonParser parser;
+    private final JsonPointerTree tree;
+    private final int size;
+
+    private ArrayDeque<JsonPointerTree> pointerStack;
+    private ArrayDeque<ParsingContext> parsingStack;
+    private ArrayDeque<StructureBuilder> builderStack;
+
+    private boolean hasFinished;
+    private JsonValue[] values;
+}

--- a/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
@@ -43,6 +43,7 @@ class InternalJsonValuesReader {
             final long defaultLong) {
         this.parser = parser;
         this.tree = tree;
+        this.hasRootToCapture = this.tree.captures().isEmpty();
 
         this.withNumbersFallbackWithLiterals = withNumbersFallbackWithLiterals;
         this.defaultDouble = defaultDouble;
@@ -87,7 +88,7 @@ class InternalJsonValuesReader {
 
         final JsonPointerTree parentPointer = this.pointerStack.peekFirst();
 
-        if (this.parsingStack.isEmpty() && token.isStructStart()) {
+        if (this.hasRootToCapture && this.parsingStack.isEmpty() && token.isStructStart()) {
             if (token == JsonToken.START_ARRAY) {
                 this.builderStack.push(new ArrayBuilder());
             } else if (token == JsonToken.START_OBJECT) {
@@ -435,6 +436,7 @@ class InternalJsonValuesReader {
 
     private final JsonParser parser;
     private final JsonPointerTree tree;
+    private final boolean hasRootToCapture;
     private final int size;
 
     private final ArrayDeque<JsonPointerTree> pointerStack;

--- a/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValuesReader.java
@@ -145,7 +145,10 @@ class InternalJsonValuesReader {
             this.parsingStack.push(new ParsingContext(false));
 
             final List<Integer> captures = this.pointerStack.getFirst().captures();
-            if (!captures.isEmpty()) {
+            // When |captures| is not empty for the JSON array, the array must be built as a JsonArray instance eventually.
+            //
+            // Whenever |builderStack| is not empty, there must be something to build for the parent builder.
+            if ((!captures.isEmpty()) || (!this.builderStack.isEmpty())) {
                 this.builderStack.push(new ArrayBuilder());
             }
         } else if (token == JsonToken.END_ARRAY) {
@@ -156,7 +159,10 @@ class InternalJsonValuesReader {
             this.parsingStack.push(new ParsingContext(true));
 
             final List<Integer> captures = this.pointerStack.getFirst().captures();
-            if (!captures.isEmpty()) {
+            // When |captures| is not empty for the JSON object, the object must be built as a JsonObject instance eventually.
+            //
+            // Whenever |builderStack| is not empty, there must be something to build for the parent builder.
+            if ((!captures.isEmpty()) || (!this.builderStack.isEmpty())) {
                 this.builderStack.push(new ObjectBuilder());
             }
         } else if (token == JsonToken.END_OBJECT) {

--- a/src/main/java/org/embulk/util/json/JsonPointerTree.java
+++ b/src/main/java/org/embulk/util/json/JsonPointerTree.java
@@ -145,7 +145,7 @@ class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
         }
 
         /**
-         * Split a JSON Pointer with unescaping.
+         * Split a JSON Pointer with unescaping {@code "~0"} to {@code "~"} and {@code "~1"} to {@code "/"}.
          *
          * <ul>
          * <li>{@code "/foo/bar/baz/qux"} : {@code ["foo", "bar", "baz", "qux"]}
@@ -154,6 +154,8 @@ class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
          * <li>{@code "/"} : {@code [""]}
          * <li>{@code ""} : {@code []}
          * </ul>
+         *
+         * @see <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC 6901: JavaScript Object Notation (JSON) Pointer</a>
          */
         static List<String> split(final JsonPointer pointer) {
             JsonPointer tail = Objects.requireNonNull(pointer);

--- a/src/main/java/org/embulk/util/json/JsonPointerTree.java
+++ b/src/main/java/org/embulk/util/json/JsonPointerTree.java
@@ -124,7 +124,7 @@ class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
                 return this;
             }
 
-            final List<String> splitPointers = split(Objects.requireNonNull(pointer));
+            final List<String> splitPointers = split(pointer);
 
             Builder node = this;
             for (final String pointerElement : splitPointers) {

--- a/src/main/java/org/embulk/util/json/JsonPointerTree.java
+++ b/src/main/java/org/embulk/util/json/JsonPointerTree.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * A matching tree node of dissolved JSON Pointers.
+ *
+ * <p>For example, consider a {@link JsonPointerTree} instance that contains the following five JSON Pointers.
+ *
+ * <ul>
+ * <li>0: {@code "/foo/bar"}
+ * <li>1: {@code "/foo/baz"}
+ * <li>2: {@code "/foo/baz/qux"}
+ * <li>3: {@code "/quux/0/fred"}
+ * <li>4: {@code "/quux/1/thud"}
+ * </ul>
+ *
+ * <p>The index numbers 0, 1, ..., and 4 there in the example are called "captures".
+ * A JSON value at the corresponding JSON Pointer is captured to the capture number.
+ *
+ * <p>A {@link JsonPointerTree} instance for the example above would consist of a tree like the following.
+ *
+ * <ul>
+ * <li>{@code "foo"}
+ *   <ul>
+ *   <li>{@code "bar"} ... a JSON value at {@code "/foo/bar"} is captured to 0
+ *   <li>{@code "baz"} ... a JSON value at {@code "/foo/baz"} is captured to 1
+ *     <ul>
+ *     <li>{@code "qux"} ... a JSON value at {@code "/foo/baz/qux"} is captured to 2
+ *     </ul>
+ *   </ul>
+ * <li>{@code "quux"}
+ *   <ul>
+ *   <li>{@code "0"}
+ *     <ul>
+ *       <li>{@code "fred"} ... a JSON value at {@code "/quux/0/fred"} is captured to 3
+ *     </ul>
+ *   <li>{@code "1"}
+ *     <ul>
+ *       <li>{@code "thud"} ... a JSON value at {@code "/quux/1/thud"} is captured to 4
+ *     </ul>
+ *   </ul>
+ * </ul>
+ */
+class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
+    private JsonPointerTree(final HashMap<String, JsonPointerTree> nextSegments, final ArrayList<Integer> captures) {
+        this.nextSegments = Collections.unmodifiableMap(nextSegments);
+        if (captures.isEmpty()) {
+            this.captures = Collections.emptyList();
+        } else {
+            this.captures = Collections.unmodifiableList(captures);
+        }
+    }
+
+    private JsonPointerTree() {  // Only for INVALID.
+        this.nextSegments = null;
+        this.captures = Collections.emptyList();
+    }
+
+    /**
+     * A builder of {@link JsonPointerTree}.
+     */
+    static class Builder {
+        private Builder() {
+            this.nextSegments = new HashMap<>();
+            this.captures = new ArrayList<>();
+        }
+
+        /**
+         * Builds a {@link JsonPointerTree} instance from the builder.
+         *
+         * @return the {@code JsonPointerTree} instance built
+         */
+        JsonPointerTree build() {
+            final HashMap<String, JsonPointerTree> fixedTokens = new HashMap<>();
+            for (final Map.Entry<String, Builder> entry : this.nextSegments.entrySet()) {
+                // TODO: Remove recursions to avoid call stack overflow.
+                fixedTokens.put(entry.getKey(), entry.getValue().build());
+            }
+            return new JsonPointerTree(fixedTokens, this.captures);
+        }
+
+        /**
+         * Adds a JSON Pointer to the matcher tree.
+         *
+         * <p>Note that adding a JSON Pointer and constructing a matching tree is not a very lightweight operation.
+         * Recommended to re-use the same matching tree instance for the same matching.
+         *
+         * @param pointer  the JSON Pointer to add
+         * @param capture  the capture for the JSON Pointer
+         * @return this builder
+         */
+        Builder add(final JsonPointer pointer, final int capture) {
+            if (isJsonPointerEmpty(pointer)) {
+                throw new IllegalArgumentException("Empty JSON Pointer \"\" is not permitted.");
+            }
+
+            if (isJsonPointerRoot(pointer)) {
+                this.captures.add(capture);
+                return this;
+            }
+
+            final List<String> splitPointers = split(Objects.requireNonNull(pointer));
+
+            Builder node = this;
+            for (final String pointerElement : splitPointers) {
+                node = node.addOnThis(pointerElement);
+            }
+            node.captures.add(capture);
+            return this;
+        }
+
+        private Builder addOnThis(final String element) {
+            final Builder node = this.nextSegments.get(element);
+            if (node == null) {
+                final Builder newNode = new Builder();
+                this.nextSegments.put(element, newNode);
+                return newNode;
+            }
+            return node;
+        }
+
+        /**
+         * Split a JSON Pointer with unescaping.
+         *
+         * <ul>
+         * <li>{@code "/foo/bar/baz/qux"} : {@code ["foo", "bar", "baz", "qux"]}
+         * <li>{@code "/1/2/3/4"} : {@code ["1", "2", "3", "4"]}
+         * <li>{@code "/f~0o"} : {@code ["f~o"]}
+         * <li>{@code "/"} : {@code [""]}
+         * <li>{@code ""} : {@code []}
+         * </ul>
+         */
+        static List<String> split(final JsonPointer pointer) {
+            JsonPointer tail = Objects.requireNonNull(pointer);
+
+            final ArrayList<String> list = new ArrayList<>();
+            while (tail != null) {
+                if (isJsonPointerEmpty(tail)) {
+                    break;
+                }
+                list.add(tail.getMatchingProperty());
+                tail = tail.tail();
+            }
+
+            return Collections.unmodifiableList(list);
+        }
+
+        private final HashMap<String, Builder> nextSegments;
+
+        private final ArrayList<Integer> captures;
+    }
+
+    /**
+     * Creates a new builder instance for {@link JsonPointerTree}.
+     *
+     * @return the new builder instance
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds a {@link JsonPointerTree} from an array of {@link JsonPointer}s.
+     *
+     * <p>It assigns the indices of the array as captures of the {@code JsonPointerTree}.
+     *
+     * @param pointers  an array of {@code JsonPointer}s
+     * @return the new {@code JsonPointerTree} instance
+     */
+    static JsonPointerTree of(final JsonPointer... pointers) {
+        final Builder builder = builder();
+        for (int i = 0; i < pointers.length; i++) {
+            builder.add(pointers[i], i);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Returns a {@link java.util.Set} view of this {@link JsonPointerTree} matching tree node.
+     */
+    @Override
+    public Set<Map.Entry<String, JsonPointerTree>> entrySet() {
+        if (this.nextSegments == null) {
+            return Collections.emptySet();
+        }
+        return this.nextSegments.entrySet();
+    }
+
+    /**
+     * Returns {@code true} if this {@link JsonPointerTree} is invalid.
+     */
+    boolean isInvalid() {
+        return this.nextSegments == null;
+    }
+
+    /**
+     * Returns a list of captures for this {@link JsonPointerTree} node.
+     */
+    List<Integer> captures() {
+        return this.captures;
+    }
+
+    /**
+     * Returns the hash code value for this matching tree.
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.nextSegments, this.captures);
+    }
+
+    /**
+     * Compares the specified object with this matching tree for equality.
+     */
+    @Override
+    public boolean equals(final Object otherObject) {
+        if (otherObject == null) {
+            return false;
+        }
+        if (otherObject == this) {
+            return true;
+        }
+        if (!(otherObject instanceof JsonPointerTree)) {
+            return false;
+        }
+        final JsonPointerTree other = (JsonPointerTree) otherObject;
+        return Objects.equals(this.nextSegments, other.nextSegments)
+                && Objects.equals(this.captures, other.captures);
+    }
+
+    /**
+     * Returns a string representation of this matching tree.
+     */
+    @Override
+    public String toString() {
+        if (this.nextSegments == null) {
+            return "(invalid)";
+        }
+
+        if (this.captures.isEmpty()) {
+            return this.nextSegments.toString();
+        }
+        return this.captures.toString() + ":" + this.nextSegments.toString();
+    }
+
+    static final JsonPointerTree INVALID = new JsonPointerTree();
+
+    // Returns true if |pointer| is an "empty" JSON Pointer "".
+    static boolean isJsonPointerEmpty(final JsonPointer pointer) {
+        return pointer.tail() == null;
+    }
+
+    // Returns true if |pointer| is a "root" JSON Pointer "/".
+    //
+    // It can be replaced with |pointer.tail().getMatchingProperty() == null| in Jackson 2.14+,
+    // but it does not work with Jackson earlier than 2.14.
+    //
+    // See also:
+    // https://github.com/FasterXML/jackson-core/issues/788
+    // https://github.com/FasterXML/jackson-core/commit/b0f6eb9bb2d2d829efb19020e7df4d732066f8cd
+    static boolean isJsonPointerRoot(final JsonPointer pointer) {
+        return "/".equals(pointer.toString());
+    }
+
+    private final Map<String, JsonPointerTree> nextSegments;
+
+    private final List<Integer> captures;
+}

--- a/src/main/java/org/embulk/util/json/JsonValuesReader.java
+++ b/src/main/java/org/embulk/util/json/JsonValuesReader.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import java.io.IOException;
+import org.embulk.spi.json.JsonValue;
+
+/**
+ * A reader to read a set of values captured by {@link JsonPointerTree} from {@link com.fasterxml.jackson.core.JsonParser}.
+ */
+public class JsonValuesReader {
+    private JsonValuesReader(final JsonPointerTree tree, final int size) {
+        this.tree = tree;
+        this.size = size;
+    }
+
+    /**
+     * Creates a {@link JsonValuesReader} instance with an array of {@link JsonPointer}s as captures.
+     *
+     * @param pointers  {@link JsonPointer}s as captures
+     * @return the new {@link JsonValuesReader} created
+     */
+    public static JsonValuesReader of(final JsonPointer... pointers) {
+        return new JsonValuesReader(JsonPointerTree.of(pointers), pointers.length);
+    }
+
+    /**
+     * Reads a set of values captured by {@link JsonPointer}s from {@link com.fasterxml.jackson.core.JsonParser}.
+     *
+     * <p>The read stops at the end of same level with the starting. For example, consider a case starting
+     * to read from the second object beginning (left curly brace) before {@code "bar"} in an example JSON
+     * {@code {"foo":{"bar":12,"baz":98},"qux":0}}. In this case, the read stops at the first object end
+     * (right curly brace) after {@code 98}. The {@code JsonParser} can continue parsing from {@code "qux"}.
+     *
+     * <p>The returned array of JSON values has the same length with the number of JSON Pointers given to
+     * the reader. The indices in the returned array correspond to the indices of {@link JsonPointer}s
+     * given in creating the {@link JsonValuesReader} instace by {@link #of(JsonPointer...)}.
+     *
+     * <p>For example, consider the given {@link JsonValuesReader} created like the following.</p>
+     *
+     * <pre>{@code JsonValuesReader.of(
+     *      JsonPointer.of("/foo"),
+     *      JsonPointer.of("/bar"),
+     *      JsonPointer.of("/baz"))}</pre>
+     *
+     * <p>The returned array of JSON values consists of three elements. The first element corresponds to
+     * {@code "/foo"}, the second to {@code "/bar"}, and the third to {@code "/baz"}.
+     *
+     * @param parser  {@link com.fasterxml.jackson.core.JsonParser} to read from
+     * @return an array of captured JSON values
+     * @throws IOException  when failing to read
+     */
+    public JsonValue[] readValuesCaptured(final JsonParser parser) throws IOException {
+        return this.readValuesCaptured(parser, false, 0.0, 0L);
+    }
+
+    /**
+     * Reads a set of values captured by {@link JsonPointer}s from {@link com.fasterxml.jackson.core.JsonParser}.
+     *
+     * <p>It is mostly the same with {@link #readValuesCaptured(JsonParser)}, but with some configuration on
+     * parsing numbers in JSON.
+     *
+     * @param parser  {@link com.fasterxml.jackson.core.JsonParser} to read from
+     * @param withNumbersFallbackWithLiterals  {@code true} to set a literal in {@link JsonDouble} and {@link JsonLong}
+     * @param defaultDouble  the default {@code double} value when the parser cannot parse a floating-point number
+     * @param defaultLong  the default {@code long} value when the parser cannot parse an integral number
+     * @return an array of captured JSON values
+     * @throws IOException  when failing to read
+     */
+    public JsonValue[] readValuesCaptured(
+            final JsonParser parser,
+            final boolean withNumbersFallbackWithLiterals,
+            final double defaultDouble,
+            final long defaultLong) throws IOException {
+        final InternalJsonValuesReader innerReader = new InternalJsonValuesReader(
+                parser,
+                this.tree,
+                this.size,
+                withNumbersFallbackWithLiterals,
+                defaultDouble,
+                defaultLong);
+
+        while (innerReader.next()) {
+            ;
+        }
+
+        return innerReader.peekValues();
+    }
+
+    /**
+     * Returns the number of {@link JsonPointer}s given when creating the reader.
+     */
+    public int size() {
+        return this.size;
+    }
+
+    private final JsonPointerTree tree;
+
+    private final int size;
+}

--- a/src/test/java/org/embulk/util/json/TestJsonPointerTree.java
+++ b/src/test/java/org/embulk/util/json/TestJsonPointerTree.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestJsonPointerTree {
+    @Test
+    public void testAdd() throws Exception {
+        final JsonPointerTree.Builder builder = JsonPointerTree.builder();
+        builder.add(JsonPointer.compile("/foo/bar/qux"), 0);
+        builder.add(JsonPointer.compile("/foo/baz/qux"), 1);
+        final JsonPointerTree root = builder.build();
+
+        assertEquals(1, root.size());
+        final JsonPointerTree foo = root.get("foo");
+        assertNotNull(foo);
+        assertTrue(root.captures().isEmpty());
+
+        assertEquals(2, foo.size());
+        final JsonPointerTree bar = foo.get("bar");
+        final JsonPointerTree baz = foo.get("baz");
+        assertNotNull(bar);
+        assertTrue(bar.captures().isEmpty());
+        assertNotNull(baz);
+        assertTrue(baz.captures().isEmpty());
+
+        assertEquals(1, bar.size());
+        final JsonPointerTree quxInBar = bar.get("qux");
+        assertNotNull(quxInBar);
+        assertEquals(Arrays.asList(0), quxInBar.captures());
+
+        assertEquals(1, baz.size());
+        final JsonPointerTree quxInBaz = baz.get("qux");
+        assertNotNull(quxInBaz);
+        assertEquals(Arrays.asList(1), quxInBaz.captures());
+    }
+
+    @Test
+    public void testSplit() throws Exception {
+        assertTrue(JsonPointerTree.Builder.split(JsonPointer.compile("")).isEmpty());
+        assertEquals(
+                strings(""),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/")));
+        assertEquals(
+                strings("foo"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/foo")));
+        assertEquals(
+                strings("123"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/123")));
+        assertEquals(
+                strings("foo", "bar", "baz", "qux"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/foo/bar/baz/qux")));
+        assertEquals(
+                strings("1", "2", "3", "4"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/1/2/3/4")));
+        assertEquals(
+                strings("foo", "45", "baz", "67"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/foo/45/baz/67")));
+        assertEquals(
+                strings("a~b", "~1", "/"),
+                JsonPointerTree.Builder.split(JsonPointer.compile("/a~0b/~01/~1")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ",true",
+            "/,false",
+            "/foo,false",
+            "/0,false",
+            "//,false",
+    })
+    public void testIsJsonPointerEmpty(final String pointerCsv, final String toBeEmptyInString) throws Exception {
+        final String pointer = (pointerCsv == null ? "" : pointerCsv);
+        final boolean toBeEmpty = Boolean.valueOf(toBeEmptyInString);
+        System.out.printf("\"%s\" is considered to be%s empty\n", pointer, (toBeEmpty ? "" : " not"));
+        assertEquals(toBeEmpty, JsonPointerTree.isJsonPointerEmpty(JsonPointer.compile(pointer)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ",false",
+            "/,true",
+            "/foo,false",
+            "/0,false",
+            "//,false",
+    })
+    public void testIsJsonPointerRoot(final String pointerCsv, final String toBeRootInString) throws Exception {
+        final String pointer = pointerCsv == null ? "" : pointerCsv;
+        final boolean toBeRoot = Boolean.valueOf(toBeRootInString);
+        System.out.printf("\"%s\" is considered to be%s root\n", pointer, (toBeRoot ? "" : " not"));
+        assertEquals(Boolean.valueOf(toBeRootInString), JsonPointerTree.isJsonPointerRoot(JsonPointer.compile(pointer)));
+    }
+
+    private static List<String> strings(final String... strings) {
+        final ArrayList<String> list = new ArrayList<>();
+        for (final String string : strings) {
+            list.add(string);
+        }
+        return Collections.unmodifiableList(list);
+    }
+}

--- a/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
@@ -222,7 +222,7 @@ public class TestJsonValuesReader {
         assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
         assertEquals("dummy", parser.getCurrentName());
 
-        // Confirmng that reading can continue on the same JsonParser by another JsonValuesReader.
+        // Confirming that reading can continue on the same JsonParser by another JsonValuesReader.
 
         final JsonValuesReader reader2 = JsonValuesReader.of(
                 JsonPointer.compile("/"),

--- a/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonNull;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonValuesReader {
+    @Test
+    public void testReadArray() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "[{\"foo\":12,\"bar\":true},{\"bar\":false,\"foo\":84},{\"foo\":123,\"bar\":false}]");
+
+        assertEquals(JsonToken.START_ARRAY, parser.nextToken());
+
+        final JsonValuesReader reader = JsonValuesReader.of(
+                JsonPointer.compile("/foo"),
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/none"));
+
+        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
+
+        assertEquals(4, actual1.length);
+        assertEquals(JsonLong.of(12), actual1[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(12), "bar", JsonBoolean.TRUE), actual1[1]);
+        assertEquals(JsonBoolean.TRUE, actual1[2]);
+        assertNull(actual1[3]);
+
+        assertEquals(4, actual2.length);
+        assertEquals(JsonLong.of(84), actual2[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(84), "bar", JsonBoolean.FALSE), actual2[1]);
+        assertEquals(JsonBoolean.FALSE, actual2[2]);
+        assertNull(actual2[3]);
+
+        assertEquals(4, actual3.length);
+        assertEquals(JsonLong.of(123), actual3[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(123), "bar", JsonBoolean.FALSE), actual3[1]);
+        assertEquals(JsonBoolean.FALSE, actual3[2]);
+        assertNull(actual3[3]);
+
+        assertEquals(JsonToken.END_ARRAY, parser.nextToken());
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testReadSequence() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"bar\":true,\"foo\":12}{\"foo\":84,\"bar\":false}{\"foo\":123,\"bar\":false}");
+
+        final JsonValuesReader reader = JsonValuesReader.of(
+                JsonPointer.compile("/foo"),
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/none"));
+
+        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
+
+        assertEquals(4, actual1.length);
+        assertEquals(JsonLong.of(12), actual1[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(12), "bar", JsonBoolean.TRUE), actual1[1]);
+        assertEquals(JsonBoolean.TRUE, actual1[2]);
+        assertNull(actual1[3]);
+
+        assertEquals(4, actual2.length);
+        assertEquals(JsonLong.of(84), actual2[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(84), "bar", JsonBoolean.FALSE), actual2[1]);
+        assertEquals(JsonBoolean.FALSE, actual2[2]);
+        assertNull(actual2[3]);
+
+        assertEquals(4, actual3.length);
+        assertEquals(JsonLong.of(123), actual3[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(123), "bar", JsonBoolean.FALSE), actual3[1]);
+        assertEquals(JsonBoolean.FALSE, actual3[2]);
+        assertNull(actual3[3]);
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testReadScalars() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "[12,\"foo\",null,true]");
+
+        assertEquals(JsonToken.START_ARRAY, parser.nextToken());
+
+        final JsonValuesReader reader = JsonValuesReader.of(
+                JsonPointer.compile("/foo"),
+                JsonPointer.compile("/"));
+
+        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual4 = reader.readValuesCaptured(parser);
+
+        assertEquals(2, actual1.length);
+        assertNull(actual1[0]);
+        assertEquals(JsonLong.of(12L), actual1[1]);
+
+        assertEquals(2, actual2.length);
+        assertNull(actual2[0]);
+        assertEquals(JsonString.of("foo"), actual2[1]);
+
+        assertEquals(2, actual3.length);
+        assertNull(actual3[0]);
+        assertEquals(JsonNull.NULL, actual3[1]);
+
+        assertEquals(2, actual4.length);
+        assertNull(actual4[0]);
+        assertEquals(JsonBoolean.TRUE, actual4[1]);
+
+        assertEquals(JsonToken.END_ARRAY, parser.nextToken());
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testReadMultiParsers() throws Exception {
+        final JsonValuesReader reader = JsonValuesReader.of(
+                JsonPointer.compile("/foo"),
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/none"));
+
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser1 = factory.createParser("{\"foo\":12,\"bar\":true}");
+        final JsonParser parser2 = factory.createParser("{\"bar\":false,\"foo\":84}");
+        final JsonParser parser3 = factory.createParser("{\"foo\":123,\"bar\":false}");
+
+        final JsonValue[] actual1 = reader.readValuesCaptured(parser1);
+        final JsonValue[] actual2 = reader.readValuesCaptured(parser2);
+        final JsonValue[] actual3 = reader.readValuesCaptured(parser3);
+
+        assertEquals(4, actual1.length);
+        assertEquals(JsonLong.of(12), actual1[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(12), "bar", JsonBoolean.TRUE), actual1[1]);
+        assertEquals(JsonBoolean.TRUE, actual1[2]);
+        assertNull(actual1[3]);
+        assertNull(parser1.nextToken());
+
+        assertEquals(4, actual2.length);
+        assertEquals(JsonLong.of(84), actual2[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(84), "bar", JsonBoolean.FALSE), actual2[1]);
+        assertEquals(JsonBoolean.FALSE, actual2[2]);
+        assertNull(actual2[3]);
+        assertNull(parser2.nextToken());
+
+        assertEquals(4, actual3.length);
+        assertEquals(JsonLong.of(123), actual3[0]);
+        assertEquals(JsonObject.of("foo", JsonLong.of(123), "bar", JsonBoolean.FALSE), actual3[1]);
+        assertEquals(JsonBoolean.FALSE, actual3[2]);
+        assertNull(actual3[3]);
+        assertNull(parser3.nextToken());
+    }
+
+    @Test
+    public void testReadContinued() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}{\"dummy\":{\"in\":98}}{\"unreach\":7}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/qux"),
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(5, actual1.length);
+        assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), actual1[0]);
+        assertEquals(
+                JsonObject.of(
+                        "foo", JsonLong.of(12L),
+                        "bar", JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE),
+                        "baz", JsonNull.NULL,
+                        "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
+                actual1[1]);
+        assertEquals(JsonNull.NULL, actual1[2]);
+        assertNotNull(actual1[2]);
+        assertEquals(JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE), actual1[3]);
+        assertEquals(JsonString.of("fuga"), actual1[4]);
+
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("dummy", parser.getCurrentName());
+
+        // Confirmng that reading can continue on the same JsonParser by another JsonValuesReader.
+
+        final JsonValuesReader reader2 = JsonValuesReader.of(
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/in"));
+
+        final JsonValue[] actual2 = reader2.readValuesCaptured(parser);
+
+        assertEquals(2, actual2.length);
+        assertEquals(JsonObject.of("in", JsonLong.of(98L)), actual2[0]);
+        assertEquals(JsonLong.of(98L), actual2[1]);
+
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+
+        // Confirming that reading can continue on the same JsonParser.
+
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("unreach", parser.getCurrentName());
+        assertEquals(JsonToken.VALUE_NUMBER_INT, parser.nextToken());
+        assertEquals(7L, parser.getLongValue());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+}

--- a/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValuesReader.java
@@ -35,6 +35,222 @@ import org.junit.jupiter.api.Test;
 
 public class TestJsonValuesReader {
     @Test
+    public void testRead1() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(4, actual1.length);
+        assertEquals(
+                JsonObject.of(
+                        "foo", JsonLong.of(12L),
+                        "bar", JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE),
+                        "baz", JsonNull.NULL,
+                        "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
+                actual1[0]);
+        assertEquals(JsonNull.NULL, actual1[1]);
+        assertNotNull(actual1[1]);
+        assertEquals(JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE), actual1[2]);
+        assertEquals(JsonString.of("fuga"), actual1[3]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead2() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(3, actual1.length);
+        assertEquals(
+                JsonObject.of(
+                        "foo", JsonLong.of(12L),
+                        "bar", JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE),
+                        "baz", JsonNull.NULL,
+                        "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
+                actual1[0]);
+        assertEquals(JsonNull.NULL, actual1[1]);
+        assertNotNull(actual1[1]);
+        assertEquals(JsonString.of("fuga"), actual1[2]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead3() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(4, actual1.length);
+        assertEquals(
+                JsonObject.of(
+                        "foo", JsonLong.of(12L),
+                        "bar", JsonLong.of(123L),
+                        "baz", JsonNull.NULL,
+                        "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
+                actual1[0]);
+        assertEquals(JsonNull.NULL, actual1[1]);
+        assertNotNull(actual1[1]);
+        assertEquals(JsonLong.of(123L), actual1[2]);
+        assertEquals(JsonString.of("fuga"), actual1[3]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead4() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/"),
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(3, actual1.length);
+        assertEquals(
+                JsonObject.of(
+                        "foo", JsonLong.of(12L),
+                        "bar", JsonLong.of(123L),
+                        "baz", JsonNull.NULL,
+                        "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
+                actual1[0]);
+        assertEquals(JsonNull.NULL, actual1[1]);
+        assertNotNull(actual1[1]);
+        assertEquals(JsonString.of("fuga"), actual1[2]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead5() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(3, actual1.length);
+        assertEquals(JsonNull.NULL, actual1[0]);
+        assertNotNull(actual1[0]);
+        assertEquals(JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE), actual1[1]);
+        assertEquals(JsonString.of("fuga"), actual1[2]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead6() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(2, actual1.length);
+        assertEquals(JsonNull.NULL, actual1[0]);
+        assertNotNull(actual1[0]);
+        assertEquals(JsonString.of("fuga"), actual1[1]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead7() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/bar"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(3, actual1.length);
+        assertEquals(JsonNull.NULL, actual1[0]);
+        assertNotNull(actual1[0]);
+        assertEquals(JsonLong.of(123L), actual1[1]);
+        assertEquals(JsonString.of("fuga"), actual1[2]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testRead8() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final JsonValuesReader reader1 = JsonValuesReader.of(
+                JsonPointer.compile("/baz"),
+                JsonPointer.compile("/qux/hoge"));
+
+        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+
+        assertEquals(2, actual1.length);
+        assertEquals(JsonNull.NULL, actual1[0]);
+        assertNotNull(actual1[0]);
+        assertEquals(JsonString.of("fuga"), actual1[1]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    @Test
     public void testReadArray() throws Exception {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(


### PR DESCRIPTION
It implements `JsonValuesReader` to read a set of JSON values captured by `JsonPointer`s from Jackson's `JsonParser`.

It reads a "value" from `JsonParser`'s current location until the corresponding end of the container. For example, from `{` until the corresponding `}`, or from `[` until the corresponding `]`. Then, it "captures" values matching with the given JSON Pointers from the read value.

For example, consider the given `JsonValuesReader}` created like the following.

```java
final JsonValuesReader reader = JsonValuesReader.of(
        JsonPointer.of("/foo"),
        JsonPointer.of("/bar"),
        JsonPointer.of("/baz"))

final JsonValue[] values = reader.readValuesCaptured(parser);
```

The returned array of JSON values would consist of three elements. The first element corresponds to `"/foo"`, the second to `"/bar"`, and the third to `"/baz"`. If the parser has JSON `{"bar":12,"foo":true,"baz":"hoge"}`, it returns `[true,12,"hoge"]`. (An order in the JSON does not matter.)
