### PR TITLE
Rename JsonValuesReader to CapturingJsonPointerList, with updating some Javadocs

### DIFF
--- a/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
+++ b/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
@@ -22,39 +22,44 @@ import java.io.IOException;
 import org.embulk.spi.json.JsonValue;
 
 /**
- * A reader to read a set of values captured by {@link JsonPointerTree} from {@link com.fasterxml.jackson.core.JsonParser}.
+ * A list of {@link JsonPointer}-based capturing pointers to capture JSON values.
+ *
+ * <p>The term "capturing pointer" is inspired from "capturing group" of regular expressions.
+ *
+ * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg">Groups and capturing</a>
  */
-public class JsonValuesReader {
-    private JsonValuesReader(final JsonPointerTree tree, final int size) {
+public class CapturingJsonPointerList {
+    private CapturingJsonPointerList(final JsonPointerTree tree, final int size) {
         this.tree = tree;
         this.size = size;
     }
 
     /**
-     * Creates a {@link JsonValuesReader} instance with an array of {@link JsonPointer}s as captures.
+     * Creates a {@link CapturingJsonPointerList} instance with capturing pointers by {@link JsonPointer}s.
      *
-     * @param pointers  {@link JsonPointer}s as captures
-     * @return the new {@link JsonValuesReader} created
+     * @param pointers  capturing pointers by {@link JsonPointer}s
+     * @return the new {@link CapturingJsonPointerList} created
      */
-    public static JsonValuesReader of(final JsonPointer... pointers) {
-        return new JsonValuesReader(JsonPointerTree.of(pointers), pointers.length);
+    public static CapturingJsonPointerList of(final JsonPointer... pointers) {
+        return new CapturingJsonPointerList(JsonPointerTree.of(pointers), pointers.length);
     }
 
     /**
-     * Reads a set of values captured by {@link JsonPointer}s from {@link com.fasterxml.jackson.core.JsonParser}.
+     * Captures JSON values by this list of capturing pointers, reading from {@link com.fasterxml.jackson.core.JsonParser}.
      *
-     * <p>The read stops at the end of same level with the starting. For example, consider a case starting
-     * to read from the second object beginning (left curly brace) before {@code "bar"} in an example JSON
-     * {@code {"foo":{"bar":12,"baz":98},"qux":0}}. In this case, the read stops at the first object end
-     * (right curly brace) after {@code 98}. The {@code JsonParser} can continue parsing from {@code "qux"}.
+     * <p>The read stops at the end of the same level with the starting. For example, consider capturing
+     * values from the following JSON: {@code {"foo":{"bar":12,"baz":98},"qux":0}}, starting to read from
+     * the second object beginning (left curly brace) before {@code "bar"}. In this case, the read stops
+     * at the first object end (right curly brace) after {@code 98}. The {@code JsonParser} can continue
+     * parsing from {@code "qux"}.
      *
      * <p>The returned array of JSON values has the same length with the number of JSON Pointers given to
-     * the reader. The indices in the returned array correspond to the indices of {@link JsonPointer}s
-     * given in creating the {@link JsonValuesReader} instace by {@link #of(JsonPointer...)}.
+     * {@link CapturingJsonPointerList}. The indices in the returned array correspond to the indices of
+     * {@link JsonPointer}s given to {@link CapturingJsonPointerList} by {@link #of(JsonPointer...)}.
      *
-     * <p>For example, consider the given {@link JsonValuesReader} created like the following.</p>
+     * <p>For example, consider {@link CapturingJsonPointerList} created like the following.</p>
      *
-     * <pre>{@code JsonValuesReader.of(
+     * <pre>{@code CapturingJsonPointerList.of(
      *      JsonPointer.of("/foo"),
      *      JsonPointer.of("/bar"),
      *      JsonPointer.of("/baz"))}</pre>
@@ -66,15 +71,15 @@ public class JsonValuesReader {
      * @return an array of captured JSON values
      * @throws IOException  when failing to read
      */
-    public JsonValue[] readValuesCaptured(final JsonParser parser) throws IOException {
-        return this.readValuesCaptured(parser, false, 0.0, 0L);
+    JsonValue[] captureFromParser(final JsonParser parser) throws IOException {
+        return this.captureFromParser(parser, false, 0.0, 0L);
     }
 
     /**
-     * Reads a set of values captured by {@link JsonPointer}s from {@link com.fasterxml.jackson.core.JsonParser}.
+     * Captures JSON values by this list of capturing pointers, reading from {@link com.fasterxml.jackson.core.JsonParser}.
      *
-     * <p>It is mostly the same with {@link #readValuesCaptured(JsonParser)}, but with some configuration on
-     * parsing numbers in JSON.
+     * <p>It is mostly the same with {@link #captureFromParser(JsonParser)}, but with some configuration
+     * on parsing numbers in JSON.
      *
      * @param parser  {@link com.fasterxml.jackson.core.JsonParser} to read from
      * @param withNumbersFallbackWithLiterals  {@code true} to set a literal in {@link JsonDouble} and {@link JsonLong}
@@ -83,7 +88,7 @@ public class JsonValuesReader {
      * @return an array of captured JSON values
      * @throws IOException  when failing to read
      */
-    public JsonValue[] readValuesCaptured(
+    JsonValue[] captureFromParser(
             final JsonParser parser,
             final boolean withNumbersFallbackWithLiterals,
             final double defaultDouble,
@@ -104,9 +109,9 @@ public class JsonValuesReader {
     }
 
     /**
-     * Returns the number of {@link JsonPointer}s given when creating the reader.
+     * Returns the number of capturing pointers specified.
      */
-    public int size() {
+    int size() {
         return this.size;
     }
 

--- a/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
+++ b/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
@@ -93,7 +93,7 @@ public class CapturingJsonPointerList {
             final boolean withNumbersFallbackWithLiterals,
             final double defaultDouble,
             final long defaultLong) throws IOException {
-        final InternalJsonValuesReader innerReader = new InternalJsonValuesReader(
+        final TreeBasedCapturer capturer = new TreeBasedCapturer(
                 parser,
                 this.tree,
                 this.size,
@@ -101,11 +101,11 @@ public class CapturingJsonPointerList {
                 defaultDouble,
                 defaultLong);
 
-        while (innerReader.next()) {
+        while (capturer.next()) {
             ;
         }
 
-        return innerReader.peekValues();
+        return capturer.peekValues();
     }
 
     /**

--- a/src/main/java/org/embulk/util/json/TreeBasedCapturer.java
+++ b/src/main/java/org/embulk/util/json/TreeBasedCapturer.java
@@ -33,8 +33,11 @@ import org.embulk.spi.json.JsonObject;
 import org.embulk.spi.json.JsonString;
 import org.embulk.spi.json.JsonValue;
 
-class InternalJsonValuesReader {
-    InternalJsonValuesReader(
+/**
+ * A context-ful JSON value "capturer" based on {@link JsonPointerTree}.
+ */
+class TreeBasedCapturer {
+    TreeBasedCapturer(
             final JsonParser parser,
             final JsonPointerTree tree,
             final int size,

--- a/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
@@ -33,20 +33,20 @@ import org.embulk.spi.json.JsonString;
 import org.embulk.spi.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
-public class TestJsonValuesReader {
+public class TestCapturingJsonPointerList {
     @Test
     public void testRead1() throws Exception {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(4, actual1.length);
         assertEquals(
@@ -72,12 +72,12 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(3, actual1.length);
         assertEquals(
@@ -102,13 +102,13 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(4, actual1.length);
         assertEquals(
@@ -134,12 +134,12 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(3, actual1.length);
         assertEquals(
@@ -164,12 +164,12 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(3, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -188,11 +188,11 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(2, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -210,12 +210,12 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(3, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -234,11 +234,11 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(2, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -258,15 +258,15 @@ public class TestJsonValuesReader {
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
-        final JsonValuesReader reader = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/none"));
 
-        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -297,15 +297,15 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"bar\":true,\"foo\":12}{\"foo\":84,\"bar\":false}{\"foo\":123,\"bar\":false}");
 
-        final JsonValuesReader reader = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/none"));
 
-        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -336,14 +336,14 @@ public class TestJsonValuesReader {
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
-        final JsonValuesReader reader = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"));
 
-        final JsonValue[] actual1 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual2 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual3 = reader.readValuesCaptured(parser);
-        final JsonValue[] actual4 = reader.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual4 = capturingPointers.captureFromParser(parser);
 
         assertEquals(2, actual1.length);
         assertNull(actual1[0]);
@@ -368,7 +368,7 @@ public class TestJsonValuesReader {
 
     @Test
     public void testReadMultiParsers() throws Exception {
-        final JsonValuesReader reader = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
@@ -379,9 +379,9 @@ public class TestJsonValuesReader {
         final JsonParser parser2 = factory.createParser("{\"bar\":false,\"foo\":84}");
         final JsonParser parser3 = factory.createParser("{\"foo\":123,\"bar\":false}");
 
-        final JsonValue[] actual1 = reader.readValuesCaptured(parser1);
-        final JsonValue[] actual2 = reader.readValuesCaptured(parser2);
-        final JsonValue[] actual3 = reader.readValuesCaptured(parser3);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser1);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser2);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser3);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -411,14 +411,14 @@ public class TestJsonValuesReader {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}{\"dummy\":{\"in\":98}}{\"unreach\":7}");
 
-        final JsonValuesReader reader1 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/qux"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = reader1.readValuesCaptured(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
 
         assertEquals(5, actual1.length);
         assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), actual1[0]);
@@ -438,13 +438,13 @@ public class TestJsonValuesReader {
         assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
         assertEquals("dummy", parser.getCurrentName());
 
-        // Confirming that reading can continue on the same JsonParser by another JsonValuesReader.
+        // Confirming that reading can continue on the same JsonParser by another CapturingJsonPointerList.
 
-        final JsonValuesReader reader2 = JsonValuesReader.of(
+        final CapturingJsonPointerList capturingPointers2 = CapturingJsonPointerList.of(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/in"));
 
-        final JsonValue[] actual2 = reader2.readValuesCaptured(parser);
+        final JsonValue[] actual2 = capturingPointers2.captureFromParser(parser);
 
         assertEquals(2, actual2.length);
         assertEquals(JsonObject.of("in", JsonLong.of(98L)), actual2[0]);


### PR DESCRIPTION
The internal class `InternalJsonValuesReader` is also renamed to `TreeBasedCapturer`.