### PR TITLE
Implement new JsonValueParser to parse JSON into org.embulk.spi.json.JsonValue

### DIFF
--- a/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
@@ -145,6 +145,14 @@ final class InternalJsonValueReader {
                                 values.toArray(new JsonValue[values.size()]));
                     }
 
+                    if (nextToken != JsonToken.FIELD_NAME) {
+                        throw new JsonParseException(
+                                "Unexpected token "
+                                        + nextToken
+                                        + " at "
+                                        + jacksonParser.getTokenLocation());
+                    }
+
                     final String key = jacksonParser.getCurrentName();
                     if (key == null) {
                         throw new JsonParseException(

--- a/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonNull;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
+
+final class InternalJsonValueReader {
+    InternalJsonValueReader(
+            final boolean hasLiteralsWithNumbers,
+            final boolean hasFallbacksForUnparsableNumbers,
+            final double defaultDouble,
+            final long defaultLong) {
+        this.hasLiteralsWithNumbers = hasLiteralsWithNumbers;
+        this.hasFallbacksForUnparsableNumbers = hasFallbacksForUnparsableNumbers;
+        this.defaultDouble = defaultDouble;
+        this.defaultLong = defaultLong;
+    }
+
+    JsonValue read(final JsonParser jacksonParser) throws IOException {
+        try {
+            final JsonToken token = jacksonParser.nextToken();
+            if (token == null) {
+                return null;
+            }
+            return readJsonValue(jacksonParser, token);
+        } catch (final com.fasterxml.jackson.core.JsonParseException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        } catch (final IOException ex) {
+            throw ex;
+        } catch (final JsonParseException ex) {
+            throw ex;
+        } catch (final RuntimeException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        }
+    }
+
+    void skip(final JsonParser jacksonParser) throws IOException {
+        try {
+            final JsonToken token = jacksonParser.nextToken();
+            if (token == null) {
+                throw new JsonParseException("Failed to parse JSON");
+            }
+            this.skipJsonValue(jacksonParser, token);
+        } catch (final com.fasterxml.jackson.core.JsonParseException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        } catch (final IOException ex) {
+            throw ex;
+        } catch (final JsonParseException ex) {
+            throw ex;
+        } catch (final RuntimeException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        }
+    }
+
+    private JsonValue readJsonValue(final JsonParser jacksonParser, final JsonToken token) throws IOException {
+        switch (token) {
+            case VALUE_NULL:
+                return JsonNull.NULL;
+
+            case VALUE_TRUE:
+                return JsonBoolean.TRUE;
+
+            case VALUE_FALSE:
+                return JsonBoolean.FALSE;
+
+            case VALUE_NUMBER_FLOAT:
+                if (this.hasLiteralsWithNumbers) {
+                    return JsonDouble.withLiteral(this.getDoubleValue(jacksonParser), jacksonParser.getValueAsString());
+                } else {
+                    return JsonDouble.of(this.getDoubleValue(jacksonParser));  // throws JsonParseException
+                }
+
+            case VALUE_NUMBER_INT:
+                if (this.hasLiteralsWithNumbers) {
+                    return JsonLong.withLiteral(this.getLongValue(jacksonParser), jacksonParser.getValueAsString());
+                } else {
+                    return JsonLong.of(this.getLongValue(jacksonParser));  // throws JsonParseException
+                }
+
+            case VALUE_STRING:
+                return JsonString.of(jacksonParser.getText());
+
+            case START_ARRAY:
+            {
+                final List<JsonValue> list = new ArrayList<>();
+                while (true) {
+                    final JsonToken nextToken = jacksonParser.nextToken();
+                    if (nextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting an element of an array");
+                    }
+                    if (nextToken == JsonToken.END_ARRAY) {
+                        return JsonArray.ofList(list);
+                    }
+                    list.add(this.readJsonValue(jacksonParser, nextToken));
+                }
+            }
+            // Never fall through from the previous branch of START_ARRAY.
+
+            case START_OBJECT:
+            {
+                final List<String> keys = new ArrayList<>();
+                final List<JsonValue> values = new ArrayList<>();
+
+                while (true) {
+                    final JsonToken nextToken = jacksonParser.nextToken();
+
+                    if (nextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting a key of an object");
+                    }
+                    if (nextToken == JsonToken.END_OBJECT) {
+                        return JsonObject.ofUnsafe(
+                                keys.toArray(new String[keys.size()]),
+                                values.toArray(new JsonValue[values.size()]));
+                    }
+
+                    final String key = jacksonParser.getCurrentName();
+                    if (key == null) {
+                        throw new JsonParseException(
+                                "Unexpected token "
+                                        + nextToken
+                                        + " at "
+                                        + jacksonParser.getTokenLocation());
+                    }
+
+                    final JsonToken nextNextToken = jacksonParser.nextToken();
+                    if (nextNextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting a value of an object");
+                    }
+                    final JsonValue value = this.readJsonValue(jacksonParser, nextNextToken);
+                    keys.add(key);
+                    values.add(value);
+                }
+            }
+            // Never fall through from the previous branch of START_OBJECT.
+
+            case VALUE_EMBEDDED_OBJECT:
+            case FIELD_NAME:
+            case END_ARRAY:
+            case END_OBJECT:
+            case NOT_AVAILABLE:
+            default:
+                throw new JsonParseException(
+                        "Unexpected token " + token + " at " + jacksonParser.getTokenLocation());
+        }
+    }
+
+    private void skipJsonValue(final JsonParser jacksonParser, final JsonToken token) throws IOException {
+        switch (token) {
+            case VALUE_NULL:
+            case VALUE_TRUE:
+            case VALUE_FALSE:
+            case VALUE_NUMBER_FLOAT:
+            case VALUE_NUMBER_INT:
+            case VALUE_STRING:
+                return;
+
+            case START_ARRAY:
+                while (true) {
+                    final JsonToken nextToken = jacksonParser.nextToken();
+                    if (nextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting an element of an array");
+                    }
+                    if (nextToken == JsonToken.END_ARRAY) {
+                        return;
+                    }
+                    this.skipJsonValue(jacksonParser, nextToken);
+                }
+                // Never fall through from the previous branch of START_ARRAY.
+
+            case START_OBJECT:
+                while (true) {
+                    final JsonToken nextToken = jacksonParser.nextToken();
+
+                    if (nextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting a key of an object");
+                    }
+                    if (nextToken == JsonToken.END_OBJECT) {
+                        return;
+                    }
+
+                    if (nextToken != JsonToken.FIELD_NAME) {
+                        throw new JsonParseException(
+                                "Unexpected token "
+                                        + nextToken
+                                        + " at "
+                                        + jacksonParser.getTokenLocation());
+                    }
+
+                    final JsonToken nextNextToken = jacksonParser.nextToken();
+                    if (nextNextToken == null) {
+                        throw new JsonParseException(
+                                "Unexpected end of JSON at "
+                                        + jacksonParser.getTokenLocation()
+                                        + " while expecting a value of an object");
+                    }
+                    this.skipJsonValue(jacksonParser, nextNextToken);
+                }
+                // Never fall through from the previous branch of START_OBJECT.
+
+            case VALUE_EMBEDDED_OBJECT:
+            case FIELD_NAME:
+            case END_ARRAY:
+            case END_OBJECT:
+            case NOT_AVAILABLE:
+            default:
+                throw new JsonParseException(
+                        "Unexpected token " + token + " at " + jacksonParser.getTokenLocation());
+        }
+    }
+
+    private double getDoubleValue(final JsonParser jacksonParser) throws IOException {
+        try {
+            return jacksonParser.getDoubleValue();
+        } catch (final IOException ex) {
+            if (this.hasFallbacksForUnparsableNumbers) {
+                return this.defaultDouble;
+            }
+            throw ex;
+        }
+    }
+
+    private long getLongValue(final JsonParser jacksonParser) throws IOException {
+        try {
+            return jacksonParser.getLongValue();
+        } catch (final IOException ex) {
+            if (this.hasFallbacksForUnparsableNumbers) {
+                return this.defaultLong;
+            }
+            throw ex;
+        }
+    }
+
+    private final boolean hasLiteralsWithNumbers;
+    private final boolean hasFallbacksForUnparsableNumbers;
+    private final double defaultDouble;
+    private final long defaultLong;
+}

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
+import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonValue;
+
+/**
+ * Parses a stringified JSON to Embulk's {@link org.embulk.spi.json.JsonValue}.
+ */
+public final class JsonValueParser implements Closeable {
+    private JsonValueParser(
+            final com.fasterxml.jackson.core.JsonParser jacksonParser,
+            final boolean hasLiteralsWithNumbers,
+            final boolean hasFallbacksForUnparsableNumbers,
+            final double defaultDouble,
+            final long defaultLong) {
+        this.jacksonParser = Objects.requireNonNull(jacksonParser);
+        this.valueReader = new InternalJsonValueReader(
+                hasLiteralsWithNumbers, hasFallbacksForUnparsableNumbers, defaultDouble, defaultLong);
+        this.hasLiteralsWithNumbers = hasLiteralsWithNumbers;
+        this.hasFallbacksForUnparsableNumbers = hasFallbacksForUnparsableNumbers;
+        this.defaultDouble = defaultDouble;
+        this.defaultLong = defaultLong;
+    }
+
+    /**
+     * Builds {@link JsonValueParser}.
+     */
+    public static final class Builder {
+        Builder(final JsonFactory factory) {
+            this.factory = Objects.requireNonNull(factory);
+            this.root = null;
+            this.hasLiteralsWithNumbers = false;
+            this.hasFallbacksForUnparsableNumbers = false;
+            this.defaultDouble = 0.0;
+            this.defaultLong = 0;
+        }
+
+        /**
+         * Sets the JSON Pointer to the "root" element to parse.
+         *
+         * @param root  the JSON Pointer to the root element
+         * @return this builder
+         */
+        public Builder root(final JsonPointer root) {
+            this.root = root;
+            return this;
+        }
+
+        /**
+         * Sets the JSON Pointer to the "root" element to parse.
+         *
+         * @param root  the JSON Pointer to the root element
+         * @return this builder
+         *
+         * @throws IllegalArgumentException  if the input does not present a valid JSON Pointer expression
+         */
+        public Builder root(final String root) {
+            this.root = JsonPointer.compile(root);
+            return this;
+        }
+
+        /**
+         * Enables creating {@link JsonDouble} and {@link JsonLong} instances with supplemental literal strings.
+         *
+         * <p>{@link JsonDouble#withLiteral(double,String)} and {@link JsonLong#withLiteral(long,String)} are
+         * used to create {@link JsonDouble} and {@link JsonLong} instances if enabled. The text representations
+         * from {@link com.fasterxml.jackson.core.JsonParser} are passed as literals.
+         *
+         * <p>The supplemental literal strings would help with representing unparsable numbers, such as integers
+         * larger than {@link Long.MAX_VALUE}, but literals would consume larger object heap memory.
+         *
+         * @return this builder
+         */
+        public Builder enableSupplementalLiteralsWithNumbers() {
+            this.hasLiteralsWithNumbers = true;
+            return this;
+        }
+
+        /**
+         * Enables falling back to default numbers for unparsable numbers.
+         *
+         * <p>The parser would throw an exception for unparsable numbers if falling back is not enabled.
+         *
+         * @param defaultDouble  the default for floating-point numbers
+         * @param defaultLong  the default for integral numbers
+         * @return this builder
+         */
+        public Builder fallbackForUnparsableNumbers(final double defaultDouble, final long defaultLong) {
+            this.hasFallbacksForUnparsableNumbers = true;
+            this.defaultDouble = defaultDouble;
+            this.defaultLong = defaultLong;
+            return this;
+        }
+
+        /**
+         * Builds {@link JsonValueParser} for the stringified JSON.
+         *
+         * @param json  the stringified JSON
+         * @return the {@link JsonValueParser} instance created
+         */
+        public JsonValueParser build(final String json) throws IOException {
+            return new JsonValueParser(
+                    buildJacksonParser(json),
+                    this.hasLiteralsWithNumbers,
+                    this.hasFallbacksForUnparsableNumbers,
+                    this.defaultDouble,
+                    this.defaultLong);
+        }
+
+        /**
+         * Builds {@link JsonValueParser} for the stringified JSON.
+         *
+         * @param jsonStream  {@link java.io.InputStream} of the stringified JSON
+         * @return the {@link JsonValueParser} instance created
+         */
+        public JsonValueParser build(final InputStream jsonStream) throws IOException {
+            return new JsonValueParser(
+                    buildJacksonParser(jsonStream),
+                    this.hasLiteralsWithNumbers,
+                    this.hasFallbacksForUnparsableNumbers,
+                    this.defaultDouble,
+                    this.defaultLong);
+        }
+
+        private com.fasterxml.jackson.core.JsonParser buildJacksonParser(final String json) throws IOException {
+            return this.extendJacksonParser(this.factory.createParser(Objects.requireNonNull(json)));
+        }
+
+        private com.fasterxml.jackson.core.JsonParser buildJacksonParser(final InputStream jsonStream) throws IOException {
+            return this.extendJacksonParser(this.factory.createParser(Objects.requireNonNull(jsonStream)));
+        }
+
+        private com.fasterxml.jackson.core.JsonParser extendJacksonParser(final com.fasterxml.jackson.core.JsonParser baseParser) {
+            if (this.root == null) {
+                return baseParser;
+            }
+            return new FilteringParserDelegate(
+                    baseParser,
+                    new JsonPointerBasedFilter(this.root),
+                    false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                    true  // Allow multiple matches
+                    );
+        }
+
+        private final JsonFactory factory;
+
+        private JsonPointer root;
+        private boolean hasLiteralsWithNumbers;
+        private boolean hasFallbacksForUnparsableNumbers;
+        private double defaultDouble;
+        private long defaultLong;
+    }
+
+    /**
+     * Returns a new builder.
+     *
+     * <p>It applies some default configurations for its internal {@link JsonFactory}. The defaults include:
+     *
+     * <ul>
+     * <li>Allowing JSON Strings to contain unquoted control characters
+     * <li>Allowing to recognize set of "Not-a-Number" (NaN) tokens as legal floating number values
+     * </ul>
+     *
+     * <p>Note that the defaults may change in future versions.
+     *
+     * @return the new builder
+     */
+    public static Builder builder() {
+        final JsonFactory factory = new JsonFactory();
+        factory.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        factory.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+        return builder(factory);
+    }
+
+    /**
+     * Returns a new builder with the specified {@link JsonFactory}.
+     *
+     * <p>It applies no additional configuration for the specified {@link JsonFactory}.
+     *
+     * @return the new builder
+     */
+    public static Builder builder(final JsonFactory jsonFactory) {
+        return new Builder(jsonFactory);
+    }
+
+    /**
+     * Reads a {@link org.embulk.spi.json.JsonValue} from the parser.
+     *
+     * @return the JSON value
+     * @throws IOException  if failing to read JSON
+     * @throws JsonParseException  if failing to parse JSON
+     */
+    public JsonValue readJsonValue() throws IOException {
+        return this.valueReader.read(this.jacksonParser);
+    }
+
+    /**
+     * Closes the parser.
+     *
+     * @throws IOException  if failing to close
+     */
+    @Override
+    public final void close() throws IOException {
+        this.jacksonParser.close();
+    }
+
+    private final com.fasterxml.jackson.core.JsonParser jacksonParser;
+    private final InternalJsonValueReader valueReader;
+
+    private final boolean hasLiteralsWithNumbers;
+    private final boolean hasFallbacksForUnparsableNumbers;
+    private final double defaultDouble;
+    private final long defaultLong;
+}

--- a/src/test/java/org/embulk/util/json/TestJsonValueParser.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValueParser.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonDouble;
+import org.embulk.spi.json.JsonLong;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+public class TestJsonValueParser {
+    @Test
+    public void testString() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("\"foobar\"");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonString.of("foobar"), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    public void testStringUnquoted() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("foobar");
+        assertThrows(JsonParseException.class, () -> {
+            parser.readJsonValue();
+        });
+    }
+
+    @Test
+    public void testOrdinaryInteger() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("12345");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonLong.of(12345), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testExponentialInteger1() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("12345e3");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonDouble.of(12345000.0), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testExponentialInteger2() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("123e2");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonDouble.of(12300.0), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testOrdinaryFloat() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("12345.12");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonDouble.of(12345.12), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testExponentialFloat() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("1.234512E4");
+        final JsonValue value = parser.readJsonValue();
+        assertEquals(JsonDouble.of(12345.12), value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testParseJson() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build(
+                "{\"col1\": 1, \"col2\": \"foo\", \"col3\": [1,2,3], \"col4\": {\"a\": 1}}");
+        final JsonValue value = parser.readJsonValue();
+
+        assertEquals(
+                JsonObject.of(
+                        "col1", JsonLong.of(1),
+                        "col2", JsonString.of("foo"),
+                        "col3", JsonArray.of(JsonLong.of(1), JsonLong.of(2), JsonLong.of(3)),
+                        "col4", JsonObject.of("a", JsonLong.of(1))
+                ),
+                value);
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testParseMultipleJsons() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().build("{\"col1\": 1}{\"col1\": 2}");
+        assertEquals(JsonObject.of("col1", JsonLong.of(1)), parser.readJsonValue());
+        assertEquals(JsonObject.of("col1", JsonLong.of(2)), parser.readJsonValue());
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testParseWithPointer1() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().root("/a/b").build("{\"a\": {\"b\": 1}}");
+        assertEquals(JsonLong.of(1), parser.readJsonValue());
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testParseWithPointer2() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().root("/a/1/b").build("{\"a\": [{\"b\": 1}, {\"b\": 2}]}");
+        assertEquals(JsonLong.of(2), parser.readJsonValue());
+        assertNull(parser.readJsonValue());
+    }
+
+    @Test
+    public void testParseMultipleJsonsWithPointer() throws Exception {
+        final JsonValueParser parser = JsonValueParser.builder().root("/a/b").build("{\"a\": {\"b\": 1}}{\"a\": {\"b\": 2}}");
+        assertEquals(JsonLong.of(1), parser.readJsonValue());
+        assertEquals(JsonLong.of(2), parser.readJsonValue());
+        assertNull(parser.readJsonValue());
+    }
+}

--- a/src/test/java/org/embulk/util/json/TestJsonValueParser.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValueParser.java
@@ -37,6 +37,7 @@ public class TestJsonValueParser {
         assertNull(parser.readJsonValue());
     }
 
+    @Test
     public void testStringUnquoted() throws Exception {
         final JsonValueParser parser = JsonValueParser.builder().build("foobar");
         assertThrows(JsonParseException.class, () -> {


### PR DESCRIPTION
This new `JsonValueParser` for `JsonValue` will eventually replace the existing `JsonParser` for MessagePack `Value`. (Every plugin has to replace it by themselves.)

`JsonValueParser` will add support for "capturing" multiple `JsonValue`s at once by `CapturingJsonPointerList` added in #25 and #26. However, this pull request is just simply reading value-by-value.