### PR TITLE
Implement CapturingPointers for root, and with direct member names, then JsonValueParser#captureJsonValues(CapturingPointers)

### DIFF
--- a/src/main/java/org/embulk/util/json/CapturingDirectMemberNameList.java
+++ b/src/main/java/org/embulk/util/json/CapturingDirectMemberNameList.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.embulk.spi.json.JsonValue;
+
+class CapturingDirectMemberNameList extends CapturingPointers {
+    private CapturingDirectMemberNameList(
+            final List<String> memberNames,
+            final boolean hasLiteralsWithNumbers,
+            final boolean hasFallbacksForUnparsableNumbers,
+            final double defaultDouble,
+            final long defaultLong) {
+        final HashMap<String, Integer> memberNamesMap = new HashMap<>();
+        int i = 0;
+        for (final String memberName : memberNames) {
+            memberNamesMap.put(memberName, i);
+            i++;
+        }
+        this.memberNames = Collections.unmodifiableMap(memberNamesMap);
+
+        this.size = memberNames.size();
+
+        this.valueReader = new InternalJsonValueReader(
+                hasLiteralsWithNumbers,
+                hasFallbacksForUnparsableNumbers,
+                defaultDouble,
+                defaultLong);
+    }
+
+    static CapturingDirectMemberNameList of(
+            final List<String> memberNames,
+            final boolean hasLiteralsWithNumbers,
+            final boolean hasFallbacksForUnparsableNumbers,
+            final double defaultDouble,
+            final long defaultLong) {
+        return new CapturingDirectMemberNameList(
+                Collections.unmodifiableList(new ArrayList<>(memberNames)),
+                hasLiteralsWithNumbers,
+                hasFallbacksForUnparsableNumbers,
+                defaultDouble,
+                defaultLong);
+    }
+
+    @Override
+    public JsonValue[] captureFromParser(final JsonParser jacksonParser) throws IOException {
+        final JsonValue[] values = new JsonValue[this.size];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = null;
+        }
+
+        try {
+            final JsonToken firstToken = jacksonParser.nextToken();
+            if (firstToken == null) {
+                throw new JsonParseException("Failed to parse JSON");
+            }
+            if (firstToken != JsonToken.START_OBJECT) {
+                throw new JsonParseException("Failed to parse JSON: Expected JSON Object, but " + firstToken.toString());
+            }
+        } catch (final com.fasterxml.jackson.core.JsonParseException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        } catch (final IOException ex) {
+            throw ex;
+        } catch (final JsonParseException ex) {
+            throw ex;
+        } catch (final RuntimeException ex) {
+            throw new JsonParseException("Failed to parse JSON", ex);
+        }
+
+        while (true) {
+            final JsonToken token = jacksonParser.nextToken();
+
+            if (token == null) {
+                throw new JsonParseException("Failed to parse JSON: Unexpected end");
+            }
+            if (token == JsonToken.END_OBJECT) {
+                break;
+            }
+            if (token != JsonToken.FIELD_NAME) {
+                throw new JsonParseException("Failed to parse JSON: Unexpected token: " + token.toString());
+            }
+
+            final String key = jacksonParser.getCurrentName();
+            if (key == null) {
+                throw new JsonParseException(
+                    "Unexpected token "
+                    + token
+                    + " at "
+                    + jacksonParser.getTokenLocation());
+            }
+
+            final Integer index = this.memberNames.get(key);
+            if (index == null) {
+                this.valueReader.skip(jacksonParser);
+            } else {
+                values[index] = this.valueReader.read(jacksonParser);
+            }
+        }
+
+        return values;
+    }
+
+    private final Map<String, Integer> memberNames;
+
+    private final int size;
+
+    private final InternalJsonValueReader valueReader;
+}

--- a/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.IOException;
+import org.embulk.spi.json.JsonValue;
+
+class CapturingPointerToRoot extends CapturingPointers {
+    CapturingPointerToRoot(
+            final boolean hasLiteralsWithNumbers,
+            final boolean hasFallbacksForUnparsableNumbers,
+            final double defaultDouble,
+            final long defaultLong) {
+        this.valueReader = new InternalJsonValueReader(
+                hasLiteralsWithNumbers, hasFallbacksForUnparsableNumbers, defaultDouble, defaultLong);
+    }
+
+    @Override
+    public JsonValue[] captureFromParser(final JsonParser jacksonParser) throws IOException {
+        final JsonValue[] values = new JsonValue[1];
+        values[0] = this.valueReader.read(jacksonParser);
+        return values;
+    }
+
+    private final InternalJsonValueReader valueReader;
+}

--- a/src/main/java/org/embulk/util/json/CapturingPointers.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointers.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import org.embulk.spi.json.JsonValue;
+
+/**
+ * Represents "capturing pointers" to capture JSON values from {@link JsonParser}.
+ *
+ * <p>It consists of a list of pointers, such as JSON Pointers, that represent positions in a JSON
+ * structure value, an array or an object.
+ *
+ * <p>Its {@link #captureFromParser(JsonParser)} captures JSON values by the "capturing pointers",
+ * reading from {@link com.fasterxml.jackson.core.JsonParser}. The captured JSON values are returned
+ * as an array of {@link JsonValue}s.
+ *
+ * <p>The returned array of JSON values has the same length with the number of pointers represented
+ * by this {@link CapturingPointers}. The indices in the returned array correspond to the indices of
+ * the pointers represented by this {@link CapturingPointers}.
+ *
+ * <p>For example, consider {@link CapturingPointers} created like the following.</p>
+ *
+ * <pre>{@code  final CapturingPointers pointers = jsonValueParser.capturingPointerBuilder()
+ *       .addJsonPointer("/foo")
+ *       .addJsonPointer("/bar")
+ *       .addJsonPointer("/baz").build();}</pre>
+ *
+ * <p>The returned array of JSON values would consist of three elements. The first element would
+ * correspond {@code "/foo"}, the second to {@code "/bar"}, and the third to {@code "/baz"}.
+ *
+ * <p>The term "capturing pointer" is inspired from "capturing group" of regular expressions.
+ *
+ * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg">Groups and capturing</a>
+ */
+public abstract class CapturingPointers {
+    CapturingPointers() {
+    }
+
+    /**
+     * Builds {@link CapturingPointers}.
+     *
+     * <p>Use {@link JsonValueParser#capturingPointersBuilder} to create a builder instance.
+     */
+    public static class Builder {
+        Builder(final boolean hasLiteralsWithNumbers,
+                final boolean hasFallbacksForUnparsableNumbers,
+                final double defaultDouble,
+                final long defaultLong) {
+            this.hasLiteralsWithNumbers = hasLiteralsWithNumbers;
+            this.hasFallbacksForUnparsableNumbers = hasFallbacksForUnparsableNumbers;
+            this.defaultDouble = defaultDouble;
+            this.defaultLong = defaultLong;
+
+            this.directMemberNames = new ArrayList<>();
+            this.jsonPointers = new ArrayList<>();
+            this.jsonPointerExceptions = new ArrayList<>();
+
+            this.hasAtLeastOneJsonPointer = false;
+        }
+
+        /**
+         * Adds a direct member name as a pointer to capture.
+         *
+         * <p>It works only for a JSON object. It captures a JSON value that is directly under the root JSON object
+         * with the member name.
+         *
+         * <p>For example for the following JSON object {@code {"foo": 12, "bar": 34, "baz": 56}}, {@code "foo"} as
+         * a direct member name would capture {@code 12}, and {@code "bar"} would capture {@code 34}.
+         *
+         * @param directMemberName  the direct member name to capture
+         * @return this builder
+         */
+        public Builder addDirectMemberName(final String directMemberName) {
+            this.directMemberNames.add(directMemberName);
+
+            final JsonPointer compiledPointer;
+            try {
+                compiledPointer = compileMemberNameToJsonPointer(directMemberName);
+            } catch (final RuntimeException ex) {
+                this.jsonPointerExceptions.add(ex);
+                return this;
+            }
+            this.jsonPointers.add(compiledPointer);
+
+            return this;
+        }
+
+        /**
+         * Adds a JSON Pointer to capture.
+         *
+         * <p>It captures a JSON value that is pointed by the JSON Pointer.
+         *
+         * <p>For example for the following JSON object {@code {"foo": {"bar": 12}, "baz": 56}}, {@code "/foo/bar"}
+         * as a JSON Pointer would capture {@code 12}, and {@code "/foo"} would capture {@code {"bar": 12}}.
+         *
+         * @param jsonPointer  the JSON Pointer to capture
+         * @return this builder
+         * @throws IllegalArgumentException  if the input does not present a valid JSON Pointer expression
+         */
+        public Builder addJsonPointer(final String jsonPointer) {
+            this.hasAtLeastOneJsonPointer = true;
+
+            this.directMemberNames.add(null);
+
+            this.jsonPointers.add(JsonPointer.compile(jsonPointer));
+
+            return this;
+        }
+
+        /**
+         * Adds a JSON Pointer to capture.
+         *
+         * <p>It captures a JSON value that is pointed by the JSON Pointer.
+         *
+         * <p>For example for the following JSON object {@code {"foo": {"bar": 12}, "baz": 56}}, {@code "/foo/bar"}
+         * as a JSON Pointer would capture {@code 12}, and {@code "/foo"} would capture {@code {"bar": 12}}.
+         *
+         * @param jsonPointer  the JSON Pointer to capture
+         * @return this builder
+         */
+        public Builder addJsonPointer(final JsonPointer jsonPointer) {
+            this.hasAtLeastOneJsonPointer = true;
+
+            this.directMemberNames.add(null);
+
+            this.jsonPointers.add(jsonPointer);
+
+            return this;
+        }
+
+        /**
+         * Builds "capturing pointers".
+         *
+         * @return the new capturing pointers
+         */
+        public CapturingPointers build() {
+            assert this.directMemberNames.size() == this.jsonPointers.size();
+            if (this.directMemberNames.isEmpty()) {
+                return new CapturingPointerToRoot(
+                        this.hasLiteralsWithNumbers,
+                        this.hasFallbacksForUnparsableNumbers,
+                        this.defaultDouble,
+                        this.defaultLong);
+            }
+
+            if (this.hasAtLeastOneJsonPointer) {
+                if (!this.jsonPointerExceptions.isEmpty()) {
+                    final IllegalArgumentException ex =
+                            new IllegalArgumentException("Invalid JSON Pointer(s) specified.", this.jsonPointerExceptions.get(0));
+                    for (final RuntimeException suppressed : this.jsonPointerExceptions) {
+                        ex.addSuppressed(suppressed);
+                    }
+                    throw ex;
+                }
+
+                return CapturingJsonPointerList.of(
+                        this.jsonPointers,
+                        this.hasLiteralsWithNumbers,
+                        this.hasFallbacksForUnparsableNumbers,
+                        this.defaultDouble,
+                        this.defaultLong);
+            } else {
+                return CapturingDirectMemberNameList.of(
+                        this.directMemberNames,
+                        this.hasLiteralsWithNumbers,
+                        this.hasFallbacksForUnparsableNumbers,
+                        this.defaultDouble,
+                        this.defaultLong);
+            }
+        }
+
+        private final boolean hasLiteralsWithNumbers;
+        private final boolean hasFallbacksForUnparsableNumbers;
+        private final double defaultDouble;
+        private final long defaultLong;
+
+        private final ArrayList<String> directMemberNames;
+        private final ArrayList<JsonPointer> jsonPointers;
+
+        private final ArrayList<RuntimeException> jsonPointerExceptions;
+
+        private boolean hasAtLeastOneJsonPointer;
+    }
+
+    /**
+     * Captures JSON values with the capturing pointers from the parser.
+     *
+     * @param parser  the parser to capture values from
+     * @return the array of captured JSON values
+     */
+    public abstract JsonValue[] captureFromParser(final JsonParser parser) throws IOException;
+
+    static JsonPointer compileMemberNameToJsonPointer(final String memberName) {
+        if ((!memberName.contains("~")) && (!memberName.contains("/"))) {
+            return JsonPointer.compile("/" + memberName);
+        }
+
+        final String untilde = TILDE.matcher(memberName).replaceAll("~0");
+        return JsonPointer.compile("/" + SLASH.matcher(untilde).replaceAll("~1"));
+    }
+
+    private static Pattern TILDE = Pattern.compile("~");
+
+    private static Pattern SLASH = Pattern.compile("/");
+}

--- a/src/main/java/org/embulk/util/json/CapturingPointers.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointers.java
@@ -218,7 +218,7 @@ public abstract class CapturingPointers {
         return JsonPointer.compile("/" + SLASH.matcher(untilde).replaceAll("~1"));
     }
 
-    private static Pattern TILDE = Pattern.compile("~");
+    private static final Pattern TILDE = Pattern.compile("~");
 
-    private static Pattern SLASH = Pattern.compile("/");
+    private static final Pattern SLASH = Pattern.compile("/");
 }

--- a/src/main/java/org/embulk/util/json/JsonPointerTree.java
+++ b/src/main/java/org/embulk/util/json/JsonPointerTree.java
@@ -189,7 +189,7 @@ class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
     /**
      * Builds a {@link JsonPointerTree} from an array of {@link JsonPointer}s.
      *
-     * <p>It assigns the indices of the array as captures of the {@code JsonPointerTree}.
+     * <p>It assigns the indices of the array as capturing pointers of the {@code JsonPointerTree}.
      *
      * @param pointers  an array of {@code JsonPointer}s
      * @return the new {@code JsonPointerTree} instance
@@ -198,6 +198,24 @@ class JsonPointerTree extends AbstractMap<String, JsonPointerTree> {
         final Builder builder = builder();
         for (int i = 0; i < pointers.length; i++) {
             builder.add(pointers[i], i);
+        }
+        return builder.build();
+    }
+
+    /**
+     * Builds a {@link JsonPointerTree} from a list of {@link JsonPointer}s.
+     *
+     * <p>It assigns the indices of the list as capturing pointers of the {@code JsonPointerTree}.
+     *
+     * @param pointers  a list of {@code JsonPointer}s
+     * @return the new {@code JsonPointerTree} instance
+     */
+    static JsonPointerTree of(final List<JsonPointer> pointers) {
+        final Builder builder = builder();
+        int i = 0;
+        for (final JsonPointer pointer : pointers) {
+            builder.add(pointer, i);
+            i++;
         }
         return builder.build();
     }

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -92,7 +92,7 @@ public final class JsonValueParser implements Closeable {
          * from {@link com.fasterxml.jackson.core.JsonParser} are passed as literals.
          *
          * <p>The supplemental literal strings would help with representing unparsable numbers, such as integers
-         * larger than {@link Long.MAX_VALUE}, but literals would consume larger object heap memory.
+         * larger than {@link java.lang.Long#MAX_VALUE}, but literals would consume larger object heap memory.
          *
          * @return this builder
          */
@@ -209,6 +209,21 @@ public final class JsonValueParser implements Closeable {
     }
 
     /**
+     * Returns a new builder for {@link CapturingPointers}.
+     *
+     * <p>The same configurations (such as {@link Builder#enableSupplementalLiteralsWithNumbers}) apply.
+     *
+     * @return the new builder for {@link CapturingPointers}
+     */
+    public CapturingPointers.Builder capturingPointersBuilder() {
+        return new CapturingPointers.Builder(
+                this.hasLiteralsWithNumbers,
+                this.hasFallbacksForUnparsableNumbers,
+                this.defaultDouble,
+                this.defaultLong);
+    }
+
+    /**
      * Reads a {@link org.embulk.spi.json.JsonValue} from the parser.
      *
      * @return the JSON value
@@ -217,6 +232,17 @@ public final class JsonValueParser implements Closeable {
      */
     public JsonValue readJsonValue() throws IOException {
         return this.valueReader.read(this.jacksonParser);
+    }
+
+    /**
+     * Captures {@link org.embulk.spi.json.JsonValue}s from the parser with the specified capturing pointers.
+     *
+     * @return the captured JSON values
+     * @throws IOException  if failing to read JSON
+     * @throws JsonParseException  if failing to parse JSON
+     */
+    public JsonValue[] captureJsonValues(final CapturingPointers capturingPointers) throws IOException {
+        return capturingPointers.captureFromParser(this.jacksonParser);
     }
 
     /**

--- a/src/test/java/org/embulk/util/json/TestCapturingDirectMemberNameList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingDirectMemberNameList.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import java.util.Arrays;
+import org.embulk.spi.json.JsonArray;
+import org.embulk.spi.json.JsonBoolean;
+import org.embulk.spi.json.JsonNull;
+import org.embulk.spi.json.JsonObject;
+import org.embulk.spi.json.JsonString;
+import org.embulk.spi.json.JsonValue;
+import org.junit.jupiter.api.Test;
+
+public class TestCapturingDirectMemberNameList {
+    @Test
+    public void testRead1() throws Exception {
+        final JsonFactory factory = new JsonFactory();
+        final JsonParser parser = factory.createParser(
+                "{\"foo\":{\"ignored\":[1,2,{},\"skipped\"]},\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+
+        final CapturingDirectMemberNameList capturingMembers1 = capturingMembers(
+                "bar",
+                "baz",
+                "dummy",
+                "qux");
+
+        final JsonValue[] actual1 = capturingMembers1.captureFromParser(parser);
+
+        assertEquals(4, actual1.length);
+        assertEquals(JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE), actual1[0]);
+        assertEquals(JsonNull.NULL, actual1[1]);
+        assertNotNull(actual1[1]);
+        assertNull(actual1[2]);
+        assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), actual1[3]);
+
+        // Confirming that JsonParser reaches at the end as expected.
+
+        assertNull(parser.nextToken());
+    }
+
+    private static CapturingDirectMemberNameList capturingMembers(final String... memberNames) {
+        return CapturingDirectMemberNameList.of(Arrays.asList(memberNames), false, false, 0.0, 0L);
+    }
+}

--- a/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonToken;
+import java.util.Arrays;
 import org.embulk.spi.json.JsonArray;
 import org.embulk.spi.json.JsonBoolean;
 import org.embulk.spi.json.JsonLong;
@@ -40,7 +41,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
@@ -72,7 +73,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
@@ -102,7 +103,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
@@ -134,7 +135,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
@@ -164,7 +165,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
@@ -188,7 +189,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
@@ -210,7 +211,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
@@ -234,7 +235,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
@@ -258,7 +259,7 @@ public class TestCapturingJsonPointerList {
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
-        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers = capturingPointers(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
@@ -297,7 +298,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"bar\":true,\"foo\":12}{\"foo\":84,\"bar\":false}{\"foo\":123,\"bar\":false}");
 
-        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers = capturingPointers(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
@@ -336,7 +337,7 @@ public class TestCapturingJsonPointerList {
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
-        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers = capturingPointers(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"));
 
@@ -368,7 +369,7 @@ public class TestCapturingJsonPointerList {
 
     @Test
     public void testReadMultiParsers() throws Exception {
-        final CapturingJsonPointerList capturingPointers = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers = capturingPointers(
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
@@ -411,7 +412,7 @@ public class TestCapturingJsonPointerList {
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}{\"dummy\":{\"in\":98}}{\"unreach\":7}");
 
-        final CapturingJsonPointerList capturingPointers1 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/qux"),
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
@@ -440,7 +441,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that reading can continue on the same JsonParser by another CapturingJsonPointerList.
 
-        final CapturingJsonPointerList capturingPointers2 = CapturingJsonPointerList.of(
+        final CapturingJsonPointerList capturingPointers2 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/in"));
 
@@ -464,5 +465,9 @@ public class TestCapturingJsonPointerList {
         // Confirming that JsonParser reaches at the end as expected.
 
         assertNull(parser.nextToken());
+    }
+
+    private static CapturingJsonPointerList capturingPointers(final JsonPointer... pointers) {
+        return CapturingJsonPointerList.of(Arrays.asList(pointers), false, false, 0.0, 0L);
     }
 }

--- a/src/test/java/org/embulk/util/json/TestCapturingPointers.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingPointers.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestCapturingPointers {
+    @ParameterizedTest(name = "\"{1}\" => \"{0}\"")
+    @CsvSource({
+            "/foo,foo",
+            "/,''",
+            "/~0,~",
+            "/~1,/",
+            "/~0~1,~/",
+            "/~1~0,/~",
+            "/~00~00,~0~0",
+            "/~01~01,~1~1",
+    })
+    public void testCompileMemberNameToJsonPointer(final String pointer, final String memberName) {
+        assertEquals(JsonPointer.compile(pointer), CapturingPointers.compileMemberNameToJsonPointer(memberName));
+    }
+}


### PR DESCRIPTION
It implements `JsonValueParser#captureJsonValues`, with varieties of `CapturingPointers`, not only JSON Pointers.

This is the last main implementation for v0.3.0 although some more smaller pull requests, such as refactoring, renames, error handling, tests, and fixes, may come.