### PR TITLE
Be able to build CapturingPointers before JsonValueParser

### DIFF
--- a/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
+++ b/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
@@ -56,7 +56,7 @@ class CapturingJsonPointerList extends CapturingPointers {
      *
      * <p>The returned array of JSON values has the same length with the number of JSON Pointers given to
      * {@link CapturingJsonPointerList}. The indices in the returned array correspond to the indices of
-     * {@link JsonPointer}s given to {@link CapturingJsonPointerList} by {@link #of(JsonPointer...)}.
+     * {@link JsonPointer}s given to {@link CapturingJsonPointerList} by {@link #of(List)}.
      *
      * <p>For example, consider {@link CapturingJsonPointerList} created like the following.</p>
      *

--- a/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
+++ b/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
@@ -30,20 +30,9 @@ import org.embulk.spi.json.JsonValue;
  * @see <a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#cg">Groups and capturing</a>
  */
 class CapturingJsonPointerList extends CapturingPointers {
-    private CapturingJsonPointerList(
-            final JsonPointerTree tree,
-            final int size,
-            final boolean hasLiteralsWithNumbers,
-            final boolean hasFallbacksForUnparsableNumbers,
-            final double defaultDouble,
-            final long defaultLong) {
+    private CapturingJsonPointerList(final JsonPointerTree tree, final int size) {
         this.tree = tree;
         this.size = size;
-
-        this.hasLiteralsWithNumbers = hasLiteralsWithNumbers;
-        this.hasFallbacksForUnparsableNumbers = hasFallbacksForUnparsableNumbers;
-        this.defaultDouble = defaultDouble;
-        this.defaultLong = defaultLong;
     }
 
     /**
@@ -52,19 +41,8 @@ class CapturingJsonPointerList extends CapturingPointers {
      * @param pointers  capturing pointers by {@link JsonPointer}s
      * @return the new {@link CapturingJsonPointerList} created
      */
-    static CapturingJsonPointerList of(
-            final List<JsonPointer> pointers,
-            final boolean hasLiteralsWithNumbers,
-            final boolean hasFallbacksForUnparsableNumbers,
-            final double defaultDouble,
-            final long defaultLong) {
-        return new CapturingJsonPointerList(
-                JsonPointerTree.of(pointers),
-                pointers.size(),
-                hasLiteralsWithNumbers,
-                hasFallbacksForUnparsableNumbers,
-                defaultDouble,
-                defaultLong);
+    static CapturingJsonPointerList of(final List<JsonPointer> pointers) {
+        return new CapturingJsonPointerList(JsonPointerTree.of(pointers), pointers.size());
     }
 
     /**
@@ -95,15 +73,12 @@ class CapturingJsonPointerList extends CapturingPointers {
      * @throws IOException  when failing to read
      */
     @Override
-    public JsonValue[] captureFromParser(final JsonParser parser) throws IOException {
+    JsonValue[] captureFromParser(final JsonParser parser, final InternalJsonValueReader valueReader) throws IOException {
         final TreeBasedCapturer capturer = new TreeBasedCapturer(
                 parser,
                 this.tree,
                 this.size,
-                this.hasLiteralsWithNumbers,
-                this.hasFallbacksForUnparsableNumbers,
-                this.defaultDouble,
-                this.defaultLong);
+                valueReader);
 
         while (capturer.next()) {
             ;
@@ -122,9 +97,4 @@ class CapturingJsonPointerList extends CapturingPointers {
     private final JsonPointerTree tree;
 
     private final int size;
-
-    private final boolean hasLiteralsWithNumbers;
-    private final boolean hasFallbacksForUnparsableNumbers;
-    private final double defaultDouble;
-    private final long defaultLong;
 }

--- a/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
@@ -21,21 +21,17 @@ import java.io.IOException;
 import org.embulk.spi.json.JsonValue;
 
 class CapturingPointerToRoot extends CapturingPointers {
-    CapturingPointerToRoot(
-            final boolean hasLiteralsWithNumbers,
-            final boolean hasFallbacksForUnparsableNumbers,
-            final double defaultDouble,
-            final long defaultLong) {
-        this.valueReader = new InternalJsonValueReader(
-                hasLiteralsWithNumbers, hasFallbacksForUnparsableNumbers, defaultDouble, defaultLong);
+    private CapturingPointerToRoot() {
     }
 
     @Override
-    public JsonValue[] captureFromParser(final JsonParser jacksonParser) throws IOException {
+    JsonValue[] captureFromParser(
+            final JsonParser jacksonParser,
+            final InternalJsonValueReader valueReader) throws IOException {
         final JsonValue[] values = new JsonValue[1];
-        values[0] = this.valueReader.read(jacksonParser);
+        values[0] = valueReader.read(jacksonParser);
         return values;
     }
 
-    private final InternalJsonValueReader valueReader;
+    static final CapturingPointerToRoot INSTANCE = new CapturingPointerToRoot();
 }

--- a/src/main/java/org/embulk/util/json/CapturingPointers.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointers.java
@@ -29,9 +29,9 @@ import org.embulk.spi.json.JsonValue;
  * <p>It consists of a list of pointers, such as JSON Pointers, that represent positions in a JSON
  * structure value, an array or an object.
  *
- * <p>Its {@link #captureFromParser(JsonParser)} captures JSON values by the "capturing pointers",
- * reading from {@link com.fasterxml.jackson.core.JsonParser}. The captured JSON values are returned
- * as an array of {@link JsonValue}s.
+ * <p>Its {@link #captureFromParser(JsonParser, InternalJsonValueReader)} captures JSON values by
+ * the "capturing pointers", reading from {@link com.fasterxml.jackson.core.JsonParser}. The
+ * captured JSON values are returned as an array of {@link JsonValue}s.
  *
  * <p>The returned array of JSON values has the same length with the number of pointers represented
  * by this {@link CapturingPointers}. The indices in the returned array correspond to the indices of
@@ -57,8 +57,6 @@ public abstract class CapturingPointers {
 
     /**
      * Builds {@link CapturingPointers}.
-     *
-     * <p>Use {@link JsonValueParser#capturingPointersBuilder} to create a builder instance.
      */
     public static class Builder {
         Builder() {

--- a/src/main/java/org/embulk/util/json/CapturingPointers.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointers.java
@@ -39,7 +39,7 @@ import org.embulk.spi.json.JsonValue;
  *
  * <p>For example, consider {@link CapturingPointers} created like the following.</p>
  *
- * <pre>{@code  final CapturingPointers pointers = jsonValueParser.capturingPointerBuilder()
+ * <pre>{@code  final CapturingPointers pointers = CapturingPointers.builder()
  *       .addJsonPointer("/foo")
  *       .addJsonPointer("/bar")
  *       .addJsonPointer("/baz").build();}</pre>
@@ -61,15 +61,7 @@ public abstract class CapturingPointers {
      * <p>Use {@link JsonValueParser#capturingPointersBuilder} to create a builder instance.
      */
     public static class Builder {
-        Builder(final boolean hasLiteralsWithNumbers,
-                final boolean hasFallbacksForUnparsableNumbers,
-                final double defaultDouble,
-                final long defaultLong) {
-            this.hasLiteralsWithNumbers = hasLiteralsWithNumbers;
-            this.hasFallbacksForUnparsableNumbers = hasFallbacksForUnparsableNumbers;
-            this.defaultDouble = defaultDouble;
-            this.defaultLong = defaultLong;
-
+        Builder() {
             this.directMemberNames = new ArrayList<>();
             this.jsonPointers = new ArrayList<>();
             this.jsonPointerExceptions = new ArrayList<>();
@@ -155,11 +147,7 @@ public abstract class CapturingPointers {
         public CapturingPointers build() {
             assert this.directMemberNames.size() == this.jsonPointers.size();
             if (this.directMemberNames.isEmpty()) {
-                return new CapturingPointerToRoot(
-                        this.hasLiteralsWithNumbers,
-                        this.hasFallbacksForUnparsableNumbers,
-                        this.defaultDouble,
-                        this.defaultLong);
+                return CapturingPointerToRoot.INSTANCE;
             }
 
             if (this.hasAtLeastOneJsonPointer) {
@@ -172,26 +160,11 @@ public abstract class CapturingPointers {
                     throw ex;
                 }
 
-                return CapturingJsonPointerList.of(
-                        this.jsonPointers,
-                        this.hasLiteralsWithNumbers,
-                        this.hasFallbacksForUnparsableNumbers,
-                        this.defaultDouble,
-                        this.defaultLong);
+                return CapturingJsonPointerList.of(this.jsonPointers);
             } else {
-                return CapturingDirectMemberNameList.of(
-                        this.directMemberNames,
-                        this.hasLiteralsWithNumbers,
-                        this.hasFallbacksForUnparsableNumbers,
-                        this.defaultDouble,
-                        this.defaultLong);
+                return CapturingDirectMemberNameList.of(this.directMemberNames);
             }
         }
-
-        private final boolean hasLiteralsWithNumbers;
-        private final boolean hasFallbacksForUnparsableNumbers;
-        private final double defaultDouble;
-        private final long defaultLong;
 
         private final ArrayList<String> directMemberNames;
         private final ArrayList<JsonPointer> jsonPointers;
@@ -202,12 +175,23 @@ public abstract class CapturingPointers {
     }
 
     /**
+     * Returns a new builder for {@link CapturingPointers}.
+     *
+     * @return the new builder for {@link CapturingPointers}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
      * Captures JSON values with the capturing pointers from the parser.
      *
      * @param parser  the parser to capture values from
      * @return the array of captured JSON values
      */
-    public abstract JsonValue[] captureFromParser(final JsonParser parser) throws IOException;
+    abstract JsonValue[] captureFromParser(
+            final JsonParser parser,
+            final InternalJsonValueReader valueReader) throws IOException;
 
     static JsonPointer compileMemberNameToJsonPointer(final String memberName) {
         if ((!memberName.contains("~")) && (!memberName.contains("/"))) {

--- a/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
+++ b/src/main/java/org/embulk/util/json/InternalJsonValueReader.java
@@ -42,6 +42,22 @@ final class InternalJsonValueReader {
         this.defaultLong = defaultLong;
     }
 
+    boolean hasLiteralsWithNumbers() {
+        return this.hasLiteralsWithNumbers;
+    }
+
+    boolean hasFallbacksForUnparsableNumbers() {
+        return this.hasFallbacksForUnparsableNumbers;
+    }
+
+    double defaultDouble() {
+        return this.defaultDouble;
+    }
+
+    long defaultLong() {
+        return this.defaultLong;
+    }
+
     JsonValue read(final JsonParser jacksonParser) throws IOException {
         try {
             final JsonToken token = jacksonParser.nextToken();

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -209,21 +209,6 @@ public final class JsonValueParser implements Closeable {
     }
 
     /**
-     * Returns a new builder for {@link CapturingPointers}.
-     *
-     * <p>The same configurations (such as {@link Builder#enableSupplementalLiteralsWithNumbers}) apply.
-     *
-     * @return the new builder for {@link CapturingPointers}
-     */
-    public CapturingPointers.Builder capturingPointersBuilder() {
-        return new CapturingPointers.Builder(
-                this.hasLiteralsWithNumbers,
-                this.hasFallbacksForUnparsableNumbers,
-                this.defaultDouble,
-                this.defaultLong);
-    }
-
-    /**
      * Reads a {@link org.embulk.spi.json.JsonValue} from the parser.
      *
      * @return the JSON value
@@ -242,7 +227,7 @@ public final class JsonValueParser implements Closeable {
      * @throws JsonParseException  if failing to parse JSON
      */
     public JsonValue[] captureJsonValues(final CapturingPointers capturingPointers) throws IOException {
-        return capturingPointers.captureFromParser(this.jacksonParser);
+        return capturingPointers.captureFromParser(this.jacksonParser, this.valueReader);
     }
 
     /**

--- a/src/main/java/org/embulk/util/json/TreeBasedCapturer.java
+++ b/src/main/java/org/embulk/util/json/TreeBasedCapturer.java
@@ -205,6 +205,7 @@ class TreeBasedCapturer {
 
             if (value != null) {
                 final JsonPointerTree thisPointer = this.pointerStack.peekFirst();
+                assert thisPointer != null;  // this.pointerStack must not be empty here, but asserting.
                 for (final int capture : thisPointer.captures()) {
                     this.values[capture] = value;
                 }

--- a/src/test/java/org/embulk/util/json/TestCapturingDirectMemberNameList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingDirectMemberNameList.java
@@ -37,6 +37,7 @@ public class TestCapturingDirectMemberNameList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":{\"ignored\":[1,2,{},\"skipped\"]},\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingDirectMemberNameList capturingMembers1 = capturingMembers(
                 "bar",
@@ -44,7 +45,7 @@ public class TestCapturingDirectMemberNameList {
                 "dummy",
                 "qux");
 
-        final JsonValue[] actual1 = capturingMembers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingMembers1.captureFromParser(parser, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonArray.of(JsonBoolean.TRUE, JsonBoolean.FALSE), actual1[0]);
@@ -59,6 +60,6 @@ public class TestCapturingDirectMemberNameList {
     }
 
     private static CapturingDirectMemberNameList capturingMembers(final String... memberNames) {
-        return CapturingDirectMemberNameList.of(Arrays.asList(memberNames), false, false, 0.0, 0L);
+        return CapturingDirectMemberNameList.of(Arrays.asList(memberNames));
     }
 }

--- a/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
@@ -40,6 +40,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
@@ -47,7 +48,7 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(
@@ -72,13 +73,14 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(3, actual1.length);
         assertEquals(
@@ -102,6 +104,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
@@ -109,7 +112,7 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(
@@ -134,13 +137,14 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(3, actual1.length);
         assertEquals(
@@ -164,13 +168,14 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(3, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -188,12 +193,13 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(2, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -210,13 +216,14 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(3, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -234,12 +241,13 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":123,\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/baz"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(2, actual1.length);
         assertEquals(JsonNull.NULL, actual1[0]);
@@ -256,6 +264,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "[{\"foo\":12,\"bar\":true},{\"bar\":false,\"foo\":84},{\"foo\":123,\"bar\":false}]");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
@@ -265,9 +274,9 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/none"));
 
-        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -297,6 +306,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"bar\":true,\"foo\":12}{\"foo\":84,\"bar\":false}{\"foo\":123,\"bar\":false}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers = capturingPointers(
                 JsonPointer.compile("/foo"),
@@ -304,9 +314,9 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/none"));
 
-        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -334,6 +344,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "[12,\"foo\",null,true]");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         assertEquals(JsonToken.START_ARRAY, parser.nextToken());
 
@@ -341,10 +352,10 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/foo"),
                 JsonPointer.compile("/"));
 
-        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser);
-        final JsonValue[] actual4 = capturingPointers.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser, reader);
+        final JsonValue[] actual4 = capturingPointers.captureFromParser(parser, reader);
 
         assertEquals(2, actual1.length);
         assertNull(actual1[0]);
@@ -374,15 +385,16 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/none"));
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser1 = factory.createParser("{\"foo\":12,\"bar\":true}");
         final JsonParser parser2 = factory.createParser("{\"bar\":false,\"foo\":84}");
         final JsonParser parser3 = factory.createParser("{\"foo\":123,\"bar\":false}");
 
-        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser1);
-        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser2);
-        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser3);
+        final JsonValue[] actual1 = capturingPointers.captureFromParser(parser1, reader);
+        final JsonValue[] actual2 = capturingPointers.captureFromParser(parser2, reader);
+        final JsonValue[] actual3 = capturingPointers.captureFromParser(parser3, reader);
 
         assertEquals(4, actual1.length);
         assertEquals(JsonLong.of(12), actual1[0]);
@@ -411,6 +423,7 @@ public class TestCapturingJsonPointerList {
         final JsonFactory factory = new JsonFactory();
         final JsonParser parser = factory.createParser(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}{\"dummy\":{\"in\":98}}{\"unreach\":7}");
+        final InternalJsonValueReader reader = new InternalJsonValueReader(false, false, 0.0, 0L);
 
         final CapturingJsonPointerList capturingPointers1 = capturingPointers(
                 JsonPointer.compile("/qux"),
@@ -419,7 +432,7 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/bar"),
                 JsonPointer.compile("/qux/hoge"));
 
-        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser);
+        final JsonValue[] actual1 = capturingPointers1.captureFromParser(parser, reader);
 
         assertEquals(5, actual1.length);
         assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), actual1[0]);
@@ -445,7 +458,7 @@ public class TestCapturingJsonPointerList {
                 JsonPointer.compile("/"),
                 JsonPointer.compile("/in"));
 
-        final JsonValue[] actual2 = capturingPointers2.captureFromParser(parser);
+        final JsonValue[] actual2 = capturingPointers2.captureFromParser(parser, reader);
 
         assertEquals(2, actual2.length);
         assertEquals(JsonObject.of("in", JsonLong.of(98L)), actual2[0]);
@@ -468,6 +481,6 @@ public class TestCapturingJsonPointerList {
     }
 
     private static CapturingJsonPointerList capturingPointers(final JsonPointer... pointers) {
-        return CapturingJsonPointerList.of(Arrays.asList(pointers), false, false, 0.0, 0L);
+        return CapturingJsonPointerList.of(Arrays.asList(pointers));
     }
 }

--- a/src/test/java/org/embulk/util/json/TestJsonValueParser.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValueParser.java
@@ -138,7 +138,7 @@ public class TestJsonValueParser {
     public void testCaptureJsonPointers() throws Exception {
         final JsonValueParser parser = JsonValueParser.builder().build(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
-        final CapturingPointers pointers = parser.capturingPointersBuilder()
+        final CapturingPointers pointers = CapturingPointers.builder()
                 .addJsonPointer("/foo")
                 .addJsonPointer("/")
                 .addJsonPointer("/qux").build();
@@ -159,7 +159,7 @@ public class TestJsonValueParser {
     public void testCaptureDirectMemberNames() throws Exception {
         final JsonValueParser parser = JsonValueParser.builder().build(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
-        final CapturingPointers pointers = parser.capturingPointersBuilder()
+        final CapturingPointers pointers = CapturingPointers.builder()
                 .addDirectMemberName("foo")
                 .addDirectMemberName("qux").build();
         final JsonValue[] values = parser.captureJsonValues(pointers);
@@ -172,7 +172,7 @@ public class TestJsonValueParser {
     public void testCaptureMixed() throws Exception {
         final JsonValueParser parser = JsonValueParser.builder().build(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
-        final CapturingPointers pointers = parser.capturingPointersBuilder()
+        final CapturingPointers pointers = CapturingPointers.builder()
                 .addDirectMemberName("foo")
                 .addJsonPointer("/")
                 .addJsonPointer("/qux").build();
@@ -193,7 +193,7 @@ public class TestJsonValueParser {
     public void testCaptureRoot() throws Exception {
         final JsonValueParser parser = JsonValueParser.builder().build(
                 "{\"foo\":12,\"bar\":[true,false],\"baz\":null,\"qux\":{\"hoge\":\"fuga\"}}");
-        final CapturingPointers pointers = parser.capturingPointersBuilder().build();
+        final CapturingPointers pointers = CapturingPointers.builder().build();
         final JsonValue[] values = parser.captureJsonValues(pointers);
         assertEquals(1, values.length);
         assertEquals(


### PR DESCRIPTION
`CapturingPointers` needed to be built apart from `JsonValueParser` to use it in `embulk-parser-json` efficiently.

To make it available, this pull request makes :
* value-reading options (ex. `hasLiteralsWithNumbers`) to be processed in `InternalJsonValueReader`,
* `#captureFromParser()` to take `InternalJsonValueReader` (and to be package-private), and
* `JsonValueParser` to pass `InternalJsonValueReader` to `CapturingPointers` when calling `#captureFromParser()`.

We may have some more cleanups in later pull requests, but this is the main change.