### PR TITLE
Return null when reaching at the end of input in the beginning of JsonValueParser#captureJsonValues

### DIFF
--- a/src/main/java/org/embulk/util/json/CapturingDirectMemberNameList.java
+++ b/src/main/java/org/embulk/util/json/CapturingDirectMemberNameList.java
@@ -47,15 +47,10 @@ class CapturingDirectMemberNameList extends CapturingPointers {
     JsonValue[] captureFromParser(
             final JsonParser jacksonParser,
             final InternalJsonValueReader valueReader) throws IOException {
-        final JsonValue[] values = new JsonValue[this.size];
-        for (int i = 0; i < values.length; i++) {
-            values[i] = null;
-        }
-
         try {
             final JsonToken firstToken = jacksonParser.nextToken();
             if (firstToken == null) {
-                throw new JsonParseException("Failed to parse JSON");
+                return null;
             }
             if (firstToken != JsonToken.START_OBJECT) {
                 throw new JsonParseException("Failed to parse JSON: Expected JSON Object, but " + firstToken.toString());
@@ -68,6 +63,11 @@ class CapturingDirectMemberNameList extends CapturingPointers {
             throw ex;
         } catch (final RuntimeException ex) {
             throw new JsonParseException("Failed to parse JSON", ex);
+        }
+
+        final JsonValue[] values = new JsonValue[this.size];
+        for (int i = 0; i < values.length; i++) {
+            values[i] = null;
         }
 
         while (true) {

--- a/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
+++ b/src/main/java/org/embulk/util/json/CapturingJsonPointerList.java
@@ -80,6 +80,11 @@ class CapturingJsonPointerList extends CapturingPointers {
                 this.size,
                 valueReader);
 
+        final boolean isFirstAvailable = capturer.next();
+        if (!isFirstAvailable) {
+            return null;
+        }
+
         while (capturer.next()) {
             ;
         }

--- a/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointerToRoot.java
@@ -28,8 +28,13 @@ class CapturingPointerToRoot extends CapturingPointers {
     JsonValue[] captureFromParser(
             final JsonParser jacksonParser,
             final InternalJsonValueReader valueReader) throws IOException {
+        final JsonValue value = valueReader.read(jacksonParser);
+        if (value == null) {
+            return null;
+        }
+
         final JsonValue[] values = new JsonValue[1];
-        values[0] = valueReader.read(jacksonParser);
+        values[0] = value;
         return values;
     }
 

--- a/src/main/java/org/embulk/util/json/CapturingPointers.java
+++ b/src/main/java/org/embulk/util/json/CapturingPointers.java
@@ -185,7 +185,7 @@ public abstract class CapturingPointers {
      * Captures JSON values with the capturing pointers from the parser.
      *
      * @param parser  the parser to capture values from
-     * @return the array of captured JSON values
+     * @return the array of captured JSON values, or {@code null} if the parser reaches at the end of input in the beginning
      */
     abstract JsonValue[] captureFromParser(
             final JsonParser parser,

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -211,7 +211,7 @@ public final class JsonValueParser implements Closeable {
     /**
      * Reads a {@link org.embulk.spi.json.JsonValue} from the parser.
      *
-     * @return the JSON value
+     * @return the JSON value, or {@code null} if the parser reaches at the end of input in the beginning
      * @throws IOException  if failing to read JSON
      * @throws JsonParseException  if failing to parse JSON
      */
@@ -222,7 +222,7 @@ public final class JsonValueParser implements Closeable {
     /**
      * Captures {@link org.embulk.spi.json.JsonValue}s from the parser with the specified capturing pointers.
      *
-     * @return the captured JSON values
+     * @return an array of the captured JSON values, or {@code null} if the parser reaches at the end of input in the beginning
      * @throws IOException  if failing to read JSON
      * @throws JsonParseException  if failing to parse JSON
      */

--- a/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
+++ b/src/test/java/org/embulk/util/json/TestCapturingJsonPointerList.java
@@ -65,6 +65,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -96,6 +97,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -129,6 +131,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -160,6 +163,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -185,6 +189,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -208,6 +213,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -233,6 +239,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -256,6 +263,7 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -298,6 +306,7 @@ public class TestCapturingJsonPointerList {
 
         assertEquals(JsonToken.END_ARRAY, parser.nextToken());
 
+        assertNull(capturingPointers.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -336,6 +345,7 @@ public class TestCapturingJsonPointerList {
         assertEquals(JsonBoolean.FALSE, actual3[2]);
         assertNull(actual3[3]);
 
+        assertNull(capturingPointers.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -375,6 +385,7 @@ public class TestCapturingJsonPointerList {
 
         assertEquals(JsonToken.END_ARRAY, parser.nextToken());
 
+        assertNull(capturingPointers.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 
@@ -401,6 +412,7 @@ public class TestCapturingJsonPointerList {
         assertEquals(JsonObject.of("foo", JsonLong.of(12), "bar", JsonBoolean.TRUE), actual1[1]);
         assertEquals(JsonBoolean.TRUE, actual1[2]);
         assertNull(actual1[3]);
+        assertNull(capturingPointers.captureFromParser(parser1, reader));
         assertNull(parser1.nextToken());
 
         assertEquals(4, actual2.length);
@@ -408,6 +420,7 @@ public class TestCapturingJsonPointerList {
         assertEquals(JsonObject.of("foo", JsonLong.of(84), "bar", JsonBoolean.FALSE), actual2[1]);
         assertEquals(JsonBoolean.FALSE, actual2[2]);
         assertNull(actual2[3]);
+        assertNull(capturingPointers.captureFromParser(parser2, reader));
         assertNull(parser2.nextToken());
 
         assertEquals(4, actual3.length);
@@ -415,6 +428,7 @@ public class TestCapturingJsonPointerList {
         assertEquals(JsonObject.of("foo", JsonLong.of(123), "bar", JsonBoolean.FALSE), actual3[1]);
         assertEquals(JsonBoolean.FALSE, actual3[2]);
         assertNull(actual3[3]);
+        assertNull(capturingPointers.captureFromParser(parser3, reader));
         assertNull(parser3.nextToken());
     }
 
@@ -477,6 +491,8 @@ public class TestCapturingJsonPointerList {
 
         // Confirming that JsonParser reaches at the end as expected.
 
+        assertNull(capturingPointers1.captureFromParser(parser, reader));
+        assertNull(capturingPointers2.captureFromParser(parser, reader));
         assertNull(parser.nextToken());
     }
 

--- a/src/test/java/org/embulk/util/json/TestJsonValueParser.java
+++ b/src/test/java/org/embulk/util/json/TestJsonValueParser.java
@@ -153,6 +153,10 @@ public class TestJsonValueParser {
                         "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
                 values[1]);
         assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), values[2]);
+
+        // Confirming that JsonValueParser reaches at the end as expected.
+
+        assertNull(parser.captureJsonValues(pointers));
     }
 
     @Test
@@ -166,6 +170,10 @@ public class TestJsonValueParser {
         assertEquals(2, values.length);
         assertEquals(JsonLong.of(12L), values[0]);
         assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), values[1]);
+
+        // Confirming that JsonValueParser reaches at the end as expected.
+
+        assertNull(parser.captureJsonValues(pointers));
     }
 
     @Test
@@ -187,6 +195,10 @@ public class TestJsonValueParser {
                         "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
                 values[1]);
         assertEquals(JsonObject.of("hoge", JsonString.of("fuga")), values[2]);
+
+        // Confirming that JsonValueParser reaches at the end as expected.
+
+        assertNull(parser.captureJsonValues(pointers));
     }
 
     @Test
@@ -203,5 +215,9 @@ public class TestJsonValueParser {
                         "baz", JsonNull.NULL,
                         "qux", JsonObject.of("hoge", JsonString.of("fuga"))),
                 values[0]);
+
+        // Confirming that JsonValueParser reaches at the end as expected.
+
+        assertNull(parser.captureJsonValues(pointers));
     }
 }


### PR DESCRIPTION
To use `JsonValueParser#captureJsonValues` from `embulk-parser-json`, we needed to detect the end of input in the loop of `captureJsonValues` calls.

This pull request is to realize it by returning `null` when `JsonValueParser#captureJsonValues` reaches at the end of input **in the beginning of its reading**.