### PR TITLE
Implement flattening JSON Arrays

### DIFF
--- a/src/main/java/org/embulk/util/json/FlattenJsonArrayFilter.java
+++ b/src/main/java/org/embulk/util/json/FlattenJsonArrayFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import com.fasterxml.jackson.core.filter.TokenFilter;
+
+/**
+ * Simple {@link TokenFilter} implementation to flatten top-level JSON Array(s).
+ */
+class FlattenJsonArrayFilter extends TokenFilter {
+    FlattenJsonArrayFilter(final int depth) {
+        if (depth <= 0) {
+            throw new IllegalArgumentException("FlattenJsonArrayFilter must receive at least 1 as depth.");
+        }
+        this.depth = depth;
+    }
+
+    @Override
+    public TokenFilter includeElement(final int index) {
+        if (this.depth <= 1) {
+            return TokenFilter.INCLUDE_ALL;
+        }
+        return new FlattenJsonArrayFilter(this.depth - 1);
+    }
+
+    @Override
+    public TokenFilter includeProperty(final String name) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "[FlattenJsonArrayFilter depth: " + this.depth + "]";
+    }
+
+    private final int depth;
+}

--- a/src/test/java/org/embulk/util/json/TestFlattenJsonArrayFilter.java
+++ b/src/test/java/org/embulk/util/json/TestFlattenJsonArrayFilter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2023 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.json;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+public class TestFlattenJsonArrayFilter {
+    @Test
+    public void testSimple() throws IOException {
+        final com.fasterxml.jackson.core.JsonParser parser = createFilteredParser("[{\"foo\":\"bar\"}]", 1);
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("foo", parser.getValueAsString());
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("bar", parser.getValueAsString());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testMultiple() throws IOException {
+        final com.fasterxml.jackson.core.JsonParser parser = createFilteredParser("[{\"foo\":\"bar\"},{\"foo\":\"baz\"}]", 1);
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("foo", parser.getValueAsString());
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("bar", parser.getValueAsString());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("foo", parser.getValueAsString());
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("baz", parser.getValueAsString());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testNested() throws IOException {
+        final com.fasterxml.jackson.core.JsonParser parser = createFilteredParser("[[{\"foo\":\"bar\"}]]", 1);
+        assertEquals(JsonToken.START_ARRAY, parser.nextToken());
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("foo", parser.getValueAsString());
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("bar", parser.getValueAsString());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.END_ARRAY, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testNested2() throws IOException {
+        final com.fasterxml.jackson.core.JsonParser parser = createFilteredParser("[[{\"foo\":\"bar\"}]]", 2);
+        assertEquals(JsonToken.START_OBJECT, parser.nextToken());
+        assertEquals(JsonToken.FIELD_NAME, parser.nextToken());
+        assertEquals("foo", parser.getValueAsString());
+        assertEquals(JsonToken.VALUE_STRING, parser.nextToken());
+        assertEquals("bar", parser.getValueAsString());
+        assertEquals(JsonToken.END_OBJECT, parser.nextToken());
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void testNoArray() throws IOException {
+        final com.fasterxml.jackson.core.JsonParser parser = createFilteredParser("{\"foo\":\"bar\"}", 1);
+        assertNull(parser.nextToken());
+    }
+
+    @Test
+    public void test0() throws IOException {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new FlattenJsonArrayFilter(0);
+        });
+    }
+
+    private static com.fasterxml.jackson.core.JsonParser createFilteredParser(
+            final String json,
+            final int depth) throws IOException {
+        final JsonFactory factory = new JsonFactory();
+        factory.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        factory.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS);
+        return new FilteringParserDelegate(
+                factory.createParser(json),
+                new FlattenJsonArrayFilter(depth),
+                false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                true  // Allow multiple matches
+                );
+    }
+}


### PR DESCRIPTION
`embulk-parser-json` has a feature to "flatten" JSON Arrays into multiple records. It is to reproduce it in `embulk-util-json`'s `JsonValueParser`.