### PR TITLE
Bump the depended Jackson version to 2.15.3

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jacksonVersion: [ "2.6.7", "2.7.9", "2.8.11", "2.9.10", "2.10.5", "2.11.4", "2.12.7", "2.13.5", "2.14.3", "2.15.2" ]
+        jacksonVersion: [ "2.15.3" ]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up OpenJDK 8
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       hash-master: ${{ steps.hash-master.outputs.hash-master }}
       hash-main: ${{ steps.hash-main.outputs.hash-main }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - id: hash-master
@@ -30,7 +30,7 @@ jobs:
     if: needs.diff.outputs.hash-master != needs.diff.outputs.hash-main
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Checkout master

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
       hash-master: ${{ steps.hash-master.outputs.hash-master }}
       hash-main: ${{ steps.hash-main.outputs.hash-main }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - id: hash-master
@@ -30,7 +30,7 @@ jobs:
     if: needs.diff.outputs.hash-master != needs.diff.outputs.hash-main
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Checkout main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up OpenJDK 8
       uses: actions/setup-java@v3
       with:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 ext {
     if (!project.hasProperty("jacksonVersionForJacksonTest")) {
-        jacksonVersionForJacksonTest = "2.6.7"
+        jacksonVersionForJacksonTest = "2.15.3"
     }
 }
 
@@ -44,7 +44,7 @@ dependencies {
     compileOnly "org.msgpack:msgpack-core:0.8.24"
 
     // Dependencies should be "api" so that their scope would be "compile" in "pom.xml".
-    api platform("com.fasterxml.jackson:jackson-bom:2.6.7")
+    api platform("com.fasterxml.jackson:jackson-bom:2.15.3")
     api "com.fasterxml.jackson.core:jackson-core"
 
     testImplementation "org.embulk:embulk-spi:0.11"
@@ -68,7 +68,7 @@ javadoc {
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
         links "https://dev.embulk.org/embulk-spi/0.11/javadoc/"
-        links "https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/2.6.7/"
+        links "https://www.javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/2.15.3/"
         links "https://javadoc.io/doc/org.msgpack/msgpack-core/0.8.24/"
     }
 }

--- a/gradle.lockfile
+++ b/gradle.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.fasterxml.jackson.core:jackson-core:2.6.7=compileClasspath,runtimeClasspath
-com.fasterxml.jackson:jackson-bom:2.6.7=compileClasspath,runtimeClasspath
+com.fasterxml.jackson.core:jackson-core:2.15.3=compileClasspath,runtimeClasspath
+com.fasterxml.jackson:jackson-bom:2.15.3=compileClasspath,runtimeClasspath
 org.embulk:embulk-spi:0.11=compileClasspath
 org.msgpack:msgpack-core:0.8.24=compileClasspath
 org.slf4j:slf4j-api:2.0.7=compileClasspath

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
+import com.fasterxml.jackson.core.filter.TokenFilter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -177,7 +178,7 @@ public final class JsonValueParser implements Closeable {
                 parser = new FilteringParserDelegate(
                     parser,
                     new JsonPointerBasedFilter(this.root),
-                    false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                    TokenFilter.Inclusion.ONLY_INCLUDE_ALL,
                     true  // Allow multiple matches
                     );
             }
@@ -185,7 +186,7 @@ public final class JsonValueParser implements Closeable {
                 parser = new FilteringParserDelegate(
                     parser,
                     new FlattenJsonArrayFilter(this.depthToFlattenJsonArrays),
-                    false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                    TokenFilter.Inclusion.ONLY_INCLUDE_ALL,
                     true  // Allow multiple matches
                     );
             }

--- a/src/main/java/org/embulk/util/json/JsonValueParser.java
+++ b/src/main/java/org/embulk/util/json/JsonValueParser.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
 import com.fasterxml.jackson.core.filter.TokenFilter;
+import com.fasterxml.jackson.core.json.PackageVersion;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -232,6 +233,7 @@ public final class JsonValueParser implements Closeable {
      * @return the new builder
      */
     public static Builder builder(final JsonFactory jsonFactory) {
+        assertJacksonVersion();
         return new Builder(jsonFactory);
     }
 
@@ -265,6 +267,17 @@ public final class JsonValueParser implements Closeable {
     @Override
     public final void close() throws IOException {
         this.jacksonParser.close();
+    }
+
+    private static void assertJacksonVersion() {
+        if (PackageVersion.VERSION.getMajorVersion() != 2) {
+            throw new UnsupportedOperationException("embulk-util-json is not used with Jackson 2.");
+        }
+
+        final int minor = PackageVersion.VERSION.getMinorVersion();
+        if (minor < 14 || (minor == 15 && PackageVersion.VERSION.getPatchLevel() <= 2)) {
+            throw new UnsupportedOperationException("embulk-util-json is not used with Jackson 2.15.3 or later.");
+        }
     }
 
     private final com.fasterxml.jackson.core.JsonParser jacksonParser;

--- a/src/test/java/org/embulk/util/json/TestFlattenJsonArrayFilter.java
+++ b/src/test/java/org/embulk/util/json/TestFlattenJsonArrayFilter.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
+import com.fasterxml.jackson.core.filter.TokenFilter;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
@@ -105,7 +106,7 @@ public class TestFlattenJsonArrayFilter {
         return new FilteringParserDelegate(
                 factory.createParser(json),
                 new FlattenJsonArrayFilter(depth),
-                false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                TokenFilter.Inclusion.ONLY_INCLUDE_ALL,
                 true  // Allow multiple matches
                 );
     }

--- a/src/test/java/org/embulk/util/json/TestJacksonFilter.java
+++ b/src/test/java/org/embulk/util/json/TestJacksonFilter.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.filter.FilteringParserDelegate;
 import com.fasterxml.jackson.core.filter.JsonPointerBasedFilter;
+import com.fasterxml.jackson.core.filter.TokenFilter;
 import com.fasterxml.jackson.core.json.PackageVersion;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,7 +66,7 @@ public class TestJacksonFilter {
         return new FilteringParserDelegate(
                 factory.createParser(json),
                 new JsonPointerBasedFilter(jsonPointer),
-                false,  // TODO: Use com.fasterxml.jackson.core.filter.TokenFilter.Inclusion since Jackson 2.12.
+                TokenFilter.Inclusion.ONLY_INCLUDE_ALL,
                 true  // Allow multiple matches
                 );
     }

--- a/src/test/java/org/embulk/util/json/TestJacksonJsonPointer.java
+++ b/src/test/java/org/embulk/util/json/TestJacksonJsonPointer.java
@@ -32,11 +32,7 @@ public class TestJacksonJsonPointer {
     public void testEmpty() throws IOException {
         final JsonPointer empty = JsonPointer.compile("");
         assertEquals("", empty.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", empty.getMatchingProperty());
-        } else {
-            assertEquals(null, empty.getMatchingProperty());
-        }
+        assertEquals(null, empty.getMatchingProperty());
         assertTrue(empty.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), empty);
         assertNotEquals(JsonPointer.compile("/"), empty);
@@ -57,11 +53,7 @@ public class TestJacksonJsonPointer {
 
         final JsonPointer tail = root.tail();
         assertEquals("", tail.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", tail.getMatchingProperty());
-        } else {
-            assertEquals(null, tail.getMatchingProperty());
-        }
+        assertEquals(null, tail.getMatchingProperty());
         assertTrue(tail.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), tail);
         assertNotEquals(JsonPointer.compile("/"), tail);
@@ -91,11 +83,7 @@ public class TestJacksonJsonPointer {
 
         final JsonPointer tail2 = tail1.tail();
         assertEquals("", tail2.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", tail2.getMatchingProperty());
-        } else {
-            assertEquals(null, tail2.getMatchingProperty());
-        }
+        assertEquals(null, tail2.getMatchingProperty());
         assertTrue(tail2.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), tail2);
         assertNotEquals(JsonPointer.compile("/"), tail2);
@@ -116,11 +104,7 @@ public class TestJacksonJsonPointer {
 
         final JsonPointer tail = root.tail();
         assertEquals("", tail.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", tail.getMatchingProperty());
-        } else {
-            assertEquals(null, tail.getMatchingProperty());
-        }
+        assertEquals(null, tail.getMatchingProperty());
         assertTrue(tail.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), tail);
         assertNotEquals(JsonPointer.compile("/"), tail);
@@ -141,11 +125,7 @@ public class TestJacksonJsonPointer {
 
         final JsonPointer tail = root.tail();
         assertEquals("", tail.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", tail.getMatchingProperty());
-        } else {
-            assertEquals(null, tail.getMatchingProperty());
-        }
+        assertEquals(null, tail.getMatchingProperty());
         assertTrue(tail.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), tail);
         assertNotEquals(JsonPointer.compile("/"), tail);
@@ -185,11 +165,7 @@ public class TestJacksonJsonPointer {
 
         final JsonPointer tail3 = tail2.tail();
         assertEquals("", tail3.toString());
-        if (isBefore2_14_0()) {
-            assertEquals("", tail3.getMatchingProperty());
-        } else {
-            assertEquals(null, tail3.getMatchingProperty());
-        }
+        assertEquals(null, tail3.getMatchingProperty());
         assertTrue(tail3.getMatchingIndex() < 0);
         assertEquals(JsonPointer.compile(""), tail3);
         assertNotEquals(JsonPointer.compile("/"), tail3);
@@ -202,13 +178,5 @@ public class TestJacksonJsonPointer {
     @BeforeAll
     static void printJacksonVersion() {
         System.out.println("Tested with Jackson: " + PackageVersion.VERSION.toString());
-    }
-
-    // The behavior of JsonPointer.compile("").tail() is different from Jackson 2.14.0.
-    //
-    // https://github.com/FasterXML/jackson-core/issues/788
-    // https://github.com/FasterXML/jackson-core/commit/b0f6eb9bb2d2d829efb19020e7df4d732066f8cd
-    private static boolean isBefore2_14_0() {
-        return PackageVersion.VERSION.getMajorVersion() <= 2 && PackageVersion.VERSION.getMinorVersion() <= 13;
     }
 }


### PR DESCRIPTION
A fix in Jackson 2.15.3 is needed to enable this fix https://github.com/embulk/embulk-util-json/pull/33#issuecomment-1727651903 

https://github.com/FasterXML/jackson-core/pull/1111

It's time to upgrade the depended Jackson to the latest!